### PR TITLE
remove startswith() usage to support older TFs

### DIFF
--- a/modules/rds-logs/main.tf
+++ b/modules/rds-logs/main.tf
@@ -4,7 +4,8 @@ data "aws_region" "current" {}
 locals {
   account_id              = data.aws_caller_identity.current.account_id
   region                  = data.aws_region.current.name
-  log_group_prefix        = startswith(var.db_engine, "aurora") ? "aws/rds/cluster" : "aws/rds/instance"
+  is_aurora               = trimprefix(var.db_engine, "aurora") != var.db_engine // startswith() only available in TF >=1.3
+  log_group_prefix        = local.is_aurora ? "aws/rds/cluster" : "aws/rds/instance"
   log_groups              = [for log_type in var.db_log_types : "/${local.log_group_prefix}/${var.db_name}/${log_type}"]
   enable_lambda_transform = var.db_engine == "mysql" || var.db_engine == "postgresql"
   tags = merge(var.tags, {


### PR DESCRIPTION
`startswith` is only available in TF >= 1.3, so use this silly construct instead to stay compatible.