### PR TITLE
try to avoid infinite diffs

### DIFF
--- a/modules/kinesis-firehose-honeycomb/variables.tf
+++ b/modules/kinesis-firehose-honeycomb/variables.tf
@@ -38,6 +38,17 @@ variable "lambda_transform_arn" {
   description = "If enable_lambda_transform is set to true, specify a valid arn"
 }
 
+variable "lambda_processor_parameters" {
+  type        = map(string)
+  default     = {}
+  description = <<DESC
+Values passed as the Lambda processing_configuration.processors.parameters, as detailed
+at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream#processors.
+
+Do not use the default values for BufferSizeInMBs (3) and BufferIntervalInSeconds (60) or you will trigger a provider bug (https://github.com/hashicorp/terraform-provider-aws/issues/9827) resulting in infinite diffs.
+DESC
+}
+
 variable "http_buffering_size" {
   type        = number
   default     = 15


### PR DESCRIPTION
There are several bugs open against the TF provider ([eg](https://github.com/hashicorp/terraform-provider-aws/issues/9827)) about KFH processor `parameters` not "sticking" and resulting in infinite diffs. This appears to be something related to not saving the values in the statefile if they're the defaults.

We're experiencing this internally with `BufferSizeInMBs` trying to be reset each apply ([internal TF link](https://app.terraform.io/app/honeycomb/workspaces/prod/runs/run-W9obHXLNwKGNA5gY))

So … let's try not to use the defaults. While we're at it, allow setting these parameters dynamically, and also sort the keys to try and avoid any out-of-order plan shenanigans.