### PR TITLE
ci: tighten up when we run full TF tests

### DIFF
--- a/.github/workflows/test-terraform-module.yml
+++ b/.github/workflows/test-terraform-module.yml
@@ -3,9 +3,9 @@ name: Test Terraform Modules
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-      - README.md
-      - CHANGELOG.md
+    paths:
+      - '**/*.tf'
+      - '!examples/**'
 env:
   TF_VAR_honeycomb_api_key: ${{ secrets.HONEYCOMB_API_KEY }}
   AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
We only need to run the TF tests if actual relevant `.tf` files have changed. Eg, should skip things like #30 that only modified docs files.