### PR TITLE
Remove 'pro/enterprise only' disclaimer for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "honeycomb-aws-integrations" {
   rds_db_engine    = "mysql"
   rds_db_log_types = ["slowquery"] // valid types include general, slowquery, error, and audit (audit will be unstructured)
 
-  # aws metrics integration - pro/enterprise Honeycomb teams only
+  # aws metrics integration
   # enable_cloudwatch_metrics = true
 
   # s3 logfile - alb access logs

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_log_groups"></a> [cloudwatch\_log\_groups](#input\_cloudwatch\_log\_groups) | CloudWatch Log Group names to stream to Honeycomb | `list(string)` | `[]` | no |
 | <a name="input_delivery_failure_s3_bucket_name"></a> [delivery\_failure\_s3\_bucket\_name](#input\_delivery\_failure\_s3\_bucket\_name) | Name for S3 bucket that will be created to hold Kinesis Firehose delivery failures. | `string` | `"honeycomb-firehose-failures-{REGION}"` | no |
-| <a name="input_enable_cloudwatch_metrics"></a> [enable\_cloudwatch\_metrics](#input\_enable\_cloudwatch\_metrics) | Honeycomb Enterprise customers can enable CloudWatch Metrics collection by<br>      setting this to true. | `bool` | `false` | no |
+| <a name="input_enable_cloudwatch_metrics"></a> [enable\_cloudwatch\_metrics](#input\_enable\_cloudwatch\_metrics) | n/a | `bool` | `false` | no |
 | <a name="input_enable_rds_logs"></a> [enable\_rds\_logs](#input\_enable\_rds\_logs) | n/a | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment this code is running in. If set, will be added as 'env' to each event. | `string` | `""` | no |
 | <a name="input_honeycomb_api_host"></a> [honeycomb\_api\_host](#input\_honeycomb\_api\_host) | If you use a Secure Tenancy or other proxy, put its schema://host[:port] here. | `string` | `"https://api.honeycomb.io"` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -35,7 +35,7 @@ module "honeycomb-aws-integrations" {
   rds_db_engine    = "mysql"
   rds_db_log_types = ["slowquery"] // valid types include general, slowquery, error, and audit (audit will be unstructured)
 
-  # aws metrics integration - pro/enterprise Honeycomb teams only
+  # aws metrics integration
   # enable_cloudwatch_metrics = true
 
   # s3 logfile - alb access logs

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,7 +14,7 @@ module "honeycomb-aws-integrations" {
   rds_db_engine    = "mysql"
   rds_db_log_types = ["slowquery"] # valid types include general, slowquery, error, and audit (audit will be unstructured)
 
-  # aws metrics integration - pro/enterprise Honeycomb teams only
+  # aws metrics integration
   # enable_cloudwatch_metrics = true
 
   # s3 logfile - alb access logs

--- a/variables.tf
+++ b/variables.tf
@@ -112,12 +112,8 @@ variable "honeycomb_dataset" {
 }
 
 variable "enable_cloudwatch_metrics" {
-  type        = bool
-  default     = false
-  description = <<DESC
-      Honeycomb Enterprise customers can enable CloudWatch Metrics collection by
-      setting this to true.
-  DESC
+  type    = bool
+  default = false
 }
 
 variable "enable_rds_logs" {


### PR DESCRIPTION
With today's announcement of Metrics available for all teams (Free -> Enterprise) these disclaimers are no longer needed.