### PR TITLE
Supporting running lambda in a vpc

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -56,6 +56,8 @@
 | <a name="input_s3_parser_type"></a> [s3\_parser\_type](#input\_s3\_parser\_type) | The type of logfile to parse. | `string` | `""` | no |
 | <a name="input_sample_rate"></a> [sample\_rate](#input\_sample\_rate) | Sample rate - used for S3 logfiles only. See https://honeycomb.io/docs/guides/sampling/. | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to resources created by this module. | `map(string)` | `null` | no |
+| <a name="vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#vpc\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `[]` | no |
+| <a name="vpc_subnet_ids"></a> [vpc\_subnet\_ids](#vpc\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -85,5 +85,8 @@ module "s3_logfile" {
   s3_filter_suffix = var.s3_filter_suffix
   sample_rate      = var.sample_rate
 
+  vpc_subnet_ids         = var.vpc_subnet_ids != null ? var.vpc_subnet_ids : null
+  vpc_security_group_ids = var.vpc_security_group_ids != null ? var.vpc_security_group_ids : null
+
   tags = var.tags
 }

--- a/modules/s3-logfile/USAGE.md
+++ b/modules/s3-logfile/USAGE.md
@@ -51,6 +51,9 @@
 | <a name="input_s3_filter_suffix"></a> [s3\_filter\_suffix](#input\_s3\_filter\_suffix) | Suffix of files that should be processed. | `string` | `".gz"` | no |
 | <a name="input_sample_rate"></a> [sample\_rate](#input\_sample\_rate) | Sample rate. See https://honeycomb.io/docs/guides/sampling/. | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to resources created by this module. | `map(string)` | `null` | no |
+| <a name="vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#vpc\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `[]` | no |
+| <a name="vpc_subnet_ids"></a> [vpc\_subnet\_ids](#vpc\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `[]` | no |
+
 
 ## Outputs
 

--- a/modules/s3-logfile/main.tf
+++ b/modules/s3-logfile/main.tf
@@ -9,16 +9,11 @@ data "aws_arn" "kms_key" {
 
 data "aws_region" "current" {}
 
-data "aws_caller_identity" "current" {}
-
 locals {
   tags = merge(var.tags, {
     "Honeycomb Agentless" = true,
     "Terraform"           = true,
   })
-
-  account_region = data.aws_region.current.name
-  account_id     = data.aws_caller_identity.current.account_id
 }
 
 data "aws_iam_policy_document" "lambda" {
@@ -31,27 +26,6 @@ data "aws_iam_policy_document" "lambda" {
     content {
       actions   = ["kms:Decrypt"]
       resources = [trimprefix(var.kms_key_arn, "key/")]
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.vpc_subnet_ids != null && var.vpc_security_group_ids != null ? ["allow_vpc"] : []
-    content {
-      actions   = ["ec2:DescribeNetworkInterfaces", "ec2:DeleteNetworkInterface"]
-      resources = ["*"]
-    }
-  }
-  dynamic "statement" {
-    for_each = var.vpc_subnet_ids != null && var.vpc_security_group_ids != null ? ["allow_vpc"] : []
-    content {
-      actions = ["ec2:CreateNetworkInterface"]
-      resources = concat([
-        for subnet_id in var.vpc_subnet_ids : "arn:aws:ec2:${local.account_region}:${local.account_id}:subnet/${subnet_id}"
-        ], [
-        for security_group_id in var.vpc_security_group_ids : "arn:aws:ec2:${local.account_region}:${local.account_id}:security-group/${security_group_id}"
-        ], [
-        "arn:aws:ec2:${local.account_region}:${local.account_id}:network-interface/*"
-      ])
     }
   }
 }
@@ -95,6 +69,7 @@ module "s3_processor" {
   attach_policy = true
   policy        = aws_iam_policy.lambda.arn
 
+  attach_network_policy  = var.vpc_subnet_ids != null ? true : false
   vpc_subnet_ids         = var.vpc_subnet_ids != null ? var.vpc_subnet_ids : null
   vpc_security_group_ids = var.vpc_security_group_ids != null ? var.vpc_security_group_ids : null
 

--- a/modules/s3-logfile/variables.tf
+++ b/modules/s3-logfile/variables.tf
@@ -110,3 +110,15 @@ variable "tags" {
   description = "Tags to add to resources created by this module."
   default     = null
 }
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "List of security group ids when Lambda Function should run in the VPC."
+  default     = null
+}
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -176,3 +176,15 @@ variable "tags" {
   description = "Tags to add to resources created by this module."
   default     = null
 }
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "List of security group ids when Lambda Function should run in the VPC."
+  default     = null
+}
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets."
+  default     = null
+}


### PR DESCRIPTION
## Which problem is this PR solving?
In some cases it makes sense to run the lambda in a `VPC`, this uses the built-in support from the `terraform-aws-modules/lambda/aws` module.

## Short description of the changes
Using the [vpc_subnet_ids](https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws/latest#input_vpc_subnet_ids) and [vpc_security_group_ids](https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws/latest#input_vpc_security_group_ids) in the `terraform-aws-modules/lambda/aws` module.

Also setting `attach_network_policy = true` when `vpc_subnet_id != null`.
```
{
    "Statement": [
        {
            "Action": [
                "ec2:CreateNetworkInterface",
                "ec2:DescribeNetworkInterfaces",
                "ec2:DeleteNetworkInterface",
                "ec2:AssignPrivateIpAddresses",
                "ec2:UnassignPrivateIpAddresses"
            ],
            "Effect": "Allow",
            "Resource": "*"
        }
    ],
    "Version": "2012-10-17"
}
```
Attaches the policy above to the I am role
