### PR TITLE
Fix a speedbump on early setup

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,9 @@ module "failure_bucket" {
 
   bucket = local.failure_bucket
   acl    = "private"
+
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerPreferred"
 }
 
 


### PR DESCRIPTION
## Which problem is this PR solving?

Short version: applying the provided terraform from the AWS integrations quickstart fails to create a bucket ACL for me. I think it's not a local issue.

Longer version:

I made a new free Honeycomb account and went to set it up in a pretty new AWS account. This account is standalone, no SCPs or whatever, and doesn't have any weird permissions set up. I'm managing it with terraform. So, following https://docs.honeycomb.io/getting-data-in/aws/aws-integrations-quickstart/ I dropped this terraform in my code:
```
variable "honeycomb_api_key" {
  type = string
}

module "honeycomb-aws-integrations" {
  source = "honeycombio/integrations/aws"

  # aws cloudwatch logs integration
  cloudwatch_log_groups = ["/aws/lambda/thing1", "/aws/lambda/thing2"]

  #honeycomb
  honeycomb_api_key = var.honeycomb_api_key       // Honeycomb API key.
  honeycomb_dataset = "terraform-aws-integration" // Your Honeycomb dataset name that will receive the logs.
}
```

Running that failed like this:
```
╷
│ Error: error creating S3 bucket ACL for honeycomb-firehose-failures-us-east-2: AccessControlListNotSupported: The bucket does not allow ACLs
│ 	status code: 400, request id: EG2SV1ATT2XWE88D, host id: eg/K0OfB8ClO7+rrAirqZ3yMgnlO1yB1TMyRs9LpmNfqnTv/kDn+2b1beekMStS1yp3hYACDhVg=
│ 
│   with module.honeycomb-aws-integrations.module.failure_bucket.aws_s3_bucket_acl.this[0],
│   on .terraform/modules/honeycomb-aws-integrations.failure_bucket/main.tf line 40, in resource "aws_s3_bucket_acl" "this":
│   40: resource "aws_s3_bucket_acl" "this" {
│ 
╵
```

That's after successfully applying everything else. I did some troubleshooting and found a pointer to needing to set `object_ownership` on the bucket being created. I'm using your default bucket so I couldn't do that outside some light surgery on the module. Thus, this change!

This requirement is implied by, but not out and out stated in, https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl.

I tested this by deleting the created bucket and letting it run a couple of times, but I didn't undo all the honeycomb changes to my AWS account between them. If you can't see this problem crop up I'll happily run it on a fresh account.

Versions:
```
➜ terraform version
Terraform v1.4.3-dev
on darwin_arm64
+ provider registry.terraform.io/hashicorp/archive v2.3.0
+ provider registry.terraform.io/hashicorp/aws v4.63.0
+ provider registry.terraform.io/hashicorp/external v2.3.1
+ provider registry.terraform.io/hashicorp/local v2.4.0
+ provider registry.terraform.io/hashicorp/null v3.2.1
+ provider registry.terraform.io/hashicorp/random v3.5.1
+ provider registry.terraform.io/hashicorp/tls v4.0.4
```

I'm running this on an M1 Mac on OS 13.2.1 from zsh, but goodness I hope that doesn't change this.

## Short description of the changes

Added an explicit `object_ownership` as required to set `acl = "private"` and `control_object_ownership = true` which is required to set `object_ownership`.

## How to verify that this has the expected result

Run a pretty minimal terraform file, as given above, and see it fail. Then apply my change and see it succeed.

I'm definitely not a Honeycomb pro, and I'd say I'm mid at best at Terraform, so any input or pointers to other ways to do this are appreciated!