### PR TITLE
fix: be explicit about S3 access policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,11 +19,11 @@ module "failure_bucket" {
   bucket = local.failure_bucket
 
   control_object_ownership = true
-  object_ownership = "BucketOwnerEnforced"
-  block_public_policy = true
-  block_public_acls = true
-  ignore_public_acls = true
-  restrict_public_buckets = true
+  object_ownership         = "BucketOwnerEnforced"
+  block_public_policy      = true
+  block_public_acls        = true
+  ignore_public_acls       = true
+  restrict_public_buckets  = true
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,13 @@ module "failure_bucket" {
   version = "~> 3.0"
 
   bucket = local.failure_bucket
-  acl    = "private"
+
+  control_object_ownership = true
+  object_ownership = "BucketOwnerEnforced"
+  block_public_policy = true
+  block_public_acls = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
 }
 
 


### PR DESCRIPTION
In April 2023, S3 changed defaults[1] for newly created buckets to 1) block all public access and 2) disable ACLs. This meant that our previous configuration of setting `acl = private` resulted in AccessControlListNotSupported errors. Instead of enabling ACLs, just set all these things to the new AWS defaults.

[1]: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/