### PR TITLE
Feat: Moving s3_configuration {} from root block to http_endpoint_con…

### DIFF
--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -15,15 +15,6 @@ resource "aws_kinesis_firehose_delivery_stream" "http_stream" {
   name        = var.name
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose_s3_role.arn
-    bucket_arn = var.s3_failure_bucket_arn
-
-    buffer_size        = var.s3_buffer_size
-    buffer_interval    = var.s3_buffer_interval
-    compression_format = var.s3_compression_format
-  }
-
   http_endpoint_configuration {
     url                = "${var.honeycomb_api_host}/1/kinesis_events/${var.honeycomb_dataset_name}"
     name               = "honeycomb"
@@ -32,6 +23,15 @@ resource "aws_kinesis_firehose_delivery_stream" "http_stream" {
     s3_backup_mode     = var.s3_backup_mode
     buffering_size     = var.http_buffering_size
     buffering_interval = var.http_buffering_interval
+
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose_s3_role.arn
+      bucket_arn = var.s3_failure_bucket_arn
+
+      buffering_size     = var.s3_buffer_size
+      buffering_interval = var.s3_buffer_interval
+      compression_format = var.s3_compression_format
+    }
 
     request_configuration {
       content_encoding = "GZIP"
@@ -56,7 +56,6 @@ resource "aws_kinesis_firehose_delivery_stream" "http_stream" {
         }
       }
     }
-
   }
 }
 

--- a/modules/s3-logfile/USAGE.md
+++ b/modules/s3-logfile/USAGE.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 


### PR DESCRIPTION
## Which problem is this PR solving?

This is a breaking change and requires consumers to upgrade to 5.x.x AWS terraform provider

- Closes #48

## Short description of the changes
https://github.com/hashicorp/terraform-provider-aws/pull/31138


## How to verify that this has the expected result
Followed the changes specified [here](https://github.com/hashicorp/terraform-provider-aws/pull/31138) and running in dev environment 