### PR TITLE
fix: bumping terraform provider versions in modules

### DIFF
--- a/modules/cloudwatch-logs/versions.tf
+++ b/modules/cloudwatch-logs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/cloudwatch-metrics/versions.tf
+++ b/modules/cloudwatch-metrics/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/rds-logs/versions.tf
+++ b/modules/rds-logs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/s3-logfile/versions.tf
+++ b/modules/s3-logfile/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 5.0.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/tests/setup-honeycomb-aws-integrations.tf
+++ b/tests/setup-honeycomb-aws-integrations.tf
@@ -1,5 +1,10 @@
 terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"


### PR DESCRIPTION
## Short description of the changes

Bumping required aws providers to v5

## How to verify that this has the expected result
I know this is a bit cringe haha, but `"It worked on my machine"`. I ran the tests using my AWS Account. I understand that it is a bad idea to open the GitHub Action to contributors, due to the possibility of abuse.



I redacted all number replacing them with `*`
```
Plan: 60 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_pet.this: Creating...
module.rds_mysql.random_password.master_password[*]: Creating...
random_pet.this: Creation complete after *s [id=grateful-kid]
module.rds_mysql.random_password.master_password[*]: Creation complete after *s [id=none]
module.rds_mysql.module.db_option_group.aws_db_option_group.this[*]: Creating...
module.elb_logs.module.s*_processor.aws_iam_role.lambda[*]: Creating...
module.elb_logs.aws_iam_policy.lambda: Creating...
module.cloudwatch_logs.aws_iam_role.this: Creating...
module.cloudwatch_logs.module.kfh.aws_iam_role.firehose_s*_role: Creating...
module.cloudwatch_metrics.aws_iam_role.this: Creating...
module.log_group.aws_cloudwatch_log_group.this[*]: Creating...
module.firehose_failure_bucket.aws_s*_bucket.this[*]: Creating...
module.rds_mysql.module.db_parameter_group.aws_db_parameter_group.this[*]: Creating...
aws_security_group.allow_http: Creating...
module.elb_logs.aws_iam_policy.lambda: Creation complete after *s [id=arn:aws:iam::************:policy/terraform-**************************]
module.alb_logs.module.s*_processor.aws_iam_role.lambda[*]: Creating...
module.rds_mysql.module.db_option_group.aws_db_option_group.this[*]: Creation complete after *s [id=tf-integrations-rds-mysql-grateful-kid-**************************]
module.alb_logs.aws_iam_policy.lambda: Creating...
module.cloudwatch_logs.module.kfh.aws_iam_role.firehose_s*_role: Creation complete after *s [id=cwlogs-grateful-kid**************************]
module.cloudwatch_metrics.module.kfh.aws_iam_role.firehose_s*_role: Creating...
module.elb_logs.module.s*_processor.aws_iam_role.lambda[*]: Creation complete after *s [id=tf-integrations-elb-grateful-kid]
module.cloudwatch_metrics.aws_iam_role.this: Creation complete after *s [id=cwmetrics-grateful-kid**************************]
module.rds_mysql.module.db_instance.aws_cloudwatch_log_group.this["slowquery"]: Creating...
module.elb_logs.module.s*_processor.aws_cloudwatch_log_group.lambda[*]: Creating...
module.cloudwatch_logs.aws_iam_role.this: Creation complete after *s [id=cwlogs-grateful-kid**************************]
module.alb_logs.module.s*_processor.aws_cloudwatch_log_group.lambda[*]: Creating...
module.log_group.aws_cloudwatch_log_group.this[*]: Creation complete after *s [id=tf-integrations-grateful-kid]
module.alb.aws_lb_target_group.main[*]: Creating...
module.alb_logs.aws_iam_policy.lambda: Creation complete after *s [id=arn:aws:iam::************:policy/terraform-**************************]
module.elb_logs.module.s*_processor.aws_iam_role_policy_attachment.additional_one[*]: Creating...
module.alb_logs.module.s*_processor.aws_iam_role.lambda[*]: Creation complete after *s [id=tf-integrations-alb-grateful-kid]
module.alb_logs.module.s*_processor.aws_iam_role_policy_attachment.additional_one[*]: Creating...
module.cloudwatch_metrics.module.kfh.aws_iam_role.firehose_s*_role: Creation complete after *s [id=cwmetrics-grateful-kid**************************]
module.elb_logs.module.s*_processor.aws_iam_role_policy_attachment.additional_one[*]: Creation complete after *s [id=tf-integrations-elb-grateful-kid-*************************a]
module.elb_logs.module.s*_processor.aws_cloudwatch_log_group.lambda[*]: Creation complete after *s [id=/aws/lambda/tf-integrations-elb-grateful-kid]
module.elb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Reading...
module.elb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Read complete after *s [id=**********]
module.alb_logs.module.s*_processor.aws_iam_role_policy_attachment.additional_one[*]: Creation complete after *s [id=tf-integrations-alb-grateful-kid-*************************b]
module.elb_logs.module.s*_processor.aws_iam_policy.logs[*]: Creating...
module.rds_mysql.module.db_instance.aws_cloudwatch_log_group.this["slowquery"]: Creation complete after *s [id=/aws/rds/instance/tf-integrations-rds-mysql-grateful-kid/slowquery]
module.alb_logs.module.s*_processor.aws_cloudwatch_log_group.lambda[*]: Creation complete after *s [id=/aws/lambda/tf-integrations-alb-grateful-kid]
module.alb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Reading...
module.alb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Read complete after *s [id=**********]
module.alb_logs.module.s*_processor.aws_iam_policy.logs[*]: Creating...
module.elb_logs.module.s*_processor.aws_iam_policy.logs[*]: Creation complete after *s [id=arn:aws:iam::************:policy/tf-integrations-elb-grateful-kid-logs]
module.elb_logs.module.s*_processor.aws_iam_role_policy_attachment.logs[*]: Creating...
module.alb_logs.module.s*_processor.aws_iam_policy.logs[*]: Creation complete after *s [id=arn:aws:iam::************:policy/tf-integrations-alb-grateful-kid-logs]
module.alb_logs.module.s*_processor.aws_iam_role_policy_attachment.logs[*]: Creating...
module.elb_logs.module.s*_processor.aws_iam_role_policy_attachment.logs[*]: Creation complete after *s [id=tf-integrations-elb-grateful-kid-*************************c]
module.elb_logs.module.s*_processor.aws_lambda_function.this[*]: Creating...
module.alb_logs.module.s*_processor.aws_iam_role_policy_attachment.logs[*]: Creation complete after *s [id=tf-integrations-alb-grateful-kid-*************************d]
module.alb_logs.module.s*_processor.aws_lambda_function.this[*]: Creating...
aws_security_group.allow_http: Creation complete after *s [id=sg-**f**c****ca*****]
module.alb.aws_lb.this[*]: Creating...
module.elb.module.elb.aws_elb.this[*]: Creating...
module.ec*_instances.aws_instance.this[*]: Creating...
module.firehose_failure_bucket.aws_s*_bucket.this[*]: Creation complete after *s [id=honeycomb-tf-integrations-failures-grateful-kid]
module.firehose_failure_bucket.aws_s*_bucket_public_access_block.this[*]: Creating...
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Reading...
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Read complete after *s [id=**********]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Creating...
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Creating...
module.firehose_failure_bucket.aws_s*_bucket_public_access_block.this[*]: Creation complete after *s [id=honeycomb-tf-integrations-failures-grateful-kid]
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Reading...
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Read complete after *s [id=**********]
module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_s*_policy: Creating...
module.alb.aws_lb_target_group.main[*]: Creation complete after *s [id=arn:aws:elasticloadbalancing:eu-west-*:************:targetgroup/defaul**************************/*fa***b*f*ff*f*f]
module.cloudwatch_metrics.module.kfh.aws_iam_role_policy.firehose_s*_policy: Creating...
module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_s*_policy: Creation complete after *s [id=cwlogs-grateful-kid**************************:firehose_s*_policy_eu-west-*]
module.cloudwatch_metrics.module.kfh.aws_iam_role_policy.firehose_s*_policy: Creation complete after *s [id=cwmetrics-grateful-kid**************************:firehose_s*_policy_eu-west-*]
module.rds_mysql.module.db_parameter_group.aws_db_parameter_group.this[*]: Creation complete after **s [id=tf-integrations-rds-mysql-grateful-kid-**************************]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Creating...
module.elb_logs.module.s*_processor.aws_lambda_function.this[*]: Still creating... [**s elapsed]
module.alb_logs.module.s*_processor.aws_lambda_function.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.ec*_instances.aws_instance.this[*]: Still creating... [**s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.elb_logs.module.s*_processor.aws_lambda_function.this[*]: Creation complete after **s [id=tf-integrations-elb-grateful-kid]
module.elb_logs.module.log_bucket.aws_lambda_permission.allow["processor"]: Creating...
module.elb_logs.module.log_bucket.aws_lambda_permission.allow["processor"]: Creation complete after *s [id=AllowLambdaS*BucketNotification-*************************f]
module.elb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Creating...
module.alb_logs.module.s*_processor.aws_lambda_function.this[*]: Creation complete after **s [id=tf-integrations-alb-grateful-kid]
module.alb_logs.module.log_bucket.aws_lambda_permission.allow["processor"]: Creating...
module.alb_logs.module.log_bucket.aws_lambda_permission.allow["processor"]: Creation complete after *s [id=AllowLambdaS*BucketNotification-**************************]
module.alb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Creating...
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [**s elapsed]
module.elb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Creation complete after *s [id=honeycomb-tf-integrations-logs-*]
module.alb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Creation complete after *s [id=honeycomb-tf-integrations-logs-*]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.ec*_instances.aws_instance.this[*]: Still creating... [**s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.ec*_instances.aws_instance.this[*]: Still creating... [**s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.ec*_instances.aws_instance.this[*]: Still creating... [**s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.ec*_instances.aws_instance.this[*]: Still creating... [**s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [**s elapsed]
module.ec*_instances.aws_instance.this[*]: Creation complete after **s [id=i-****e*b**ab*f**ac]
module.alb.aws_lb.this[*]: Still creating... [*m*s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m*s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Creation complete after *m**s [id=arn:aws:firehose:eu-west-*:************:deliverystream/cwmetrics-grateful-kid]
module.cloudwatch_metrics.data.aws_iam_policy_document.this: Reading...
module.cloudwatch_metrics.data.aws_iam_policy_document.this: Read complete after *s [id=**********]
module.cloudwatch_metrics.aws_cloudwatch_metric_stream.metric-stream: Creating...
module.cloudwatch_metrics.aws_iam_role_policy.this: Creating...
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Creation complete after *m**s [id=arn:aws:firehose:eu-west-*:************:deliverystream/cwlogs-grateful-kid]
module.cloudwatch_logs.data.aws_iam_policy_document.this: Reading...
module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[*]: Creating...
module.cloudwatch_logs.data.aws_iam_policy_document.this: Read complete after *s [id=**********]
module.cloudwatch_logs.aws_iam_role_policy.cwl_policy: Creating...
module.cloudwatch_metrics.aws_iam_role_policy.this: Creation complete after *s [id=cwmetrics-grateful-kid**************************:cwmetrics-grateful-kid**************************]
module.cloudwatch_logs.aws_iam_role_policy.cwl_policy: Creation complete after *s [id=cwlogs-grateful-kid**************************:cwlogs-grateful-kid**************************]
module.cloudwatch_metrics.aws_cloudwatch_metric_stream.metric-stream: Creation complete after *s [id=cwmetrics-grateful-kid]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[*]: Still creating... [**s elapsed]
module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[*]: Creation complete after **s [id=cwlsf-**********]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m*s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Still creating... [*m**s elapsed]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Creation complete after *m**s [id=db-QPS***CQL**TJTWF*UCPFEMUJM]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Read complete after *s [id=**********]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Read complete after *s [id=*********]
module.rds_mysql_logs.data.aws_region.current: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_partition.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_caller_identity.current: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_region.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_region.current: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_caller_identity.current: Reading...
module.rds_mysql_logs.data.aws_caller_identity.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_region.current: Reading...
module.rds_mysql_logs.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_partition.current: Read complete after *s [id=aws]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_cloudwatch_log_group.lambda[*]: Creating...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.assume_role[*]: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.assume_role[*]: Read complete after *s [id=**********]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role.firehose_s*_role: Creating...
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role.lambda[*]: Creating...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_caller_identity.current: Read complete after *s [id=************]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_caller_identity.current: Read complete after *s [id=************]
module.rds_mysql_logs.data.aws_caller_identity.current: Read complete after *s [id=************]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.assume_role: Reading...
module.rds_mysql_logs.data.aws_iam_policy_document.lambda: Reading...
module.rds_mysql_logs.data.aws_iam_policy_document.lambda: Read complete after *s [id=**********]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.assume_role: Read complete after *s [id=*********]
module.rds_mysql_logs.module.cloudwatch_logs.aws_iam_role.this: Creating...
module.rds_mysql_logs.aws_iam_policy.lambda[*]: Creating...
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_cloudwatch_log_group.lambda[*]: Creation complete after *s [id=/aws/lambda/rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.logs[*]: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.logs[*]: Read complete after *s [id=*********]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_policy.logs[*]: Creating...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role.firehose_s*_role: Creation complete after *s [id=rds-logs-grateful-kid**************************]
module.rds_mysql_logs.aws_iam_policy.lambda[*]: Creation complete after *s [id=arn:aws:iam::************:policy/terraform-**************************]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_s*_policy: Creating...
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role.lambda[*]: Creation complete after *s [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role_policy_attachment.additional_one[*]: Creating...
module.rds_mysql_logs.module.cloudwatch_logs.aws_iam_role.this: Creation complete after *s [id=rds-logs-grateful-kid**************************]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_policy.logs[*]: Creation complete after *s [id=arn:aws:iam::************:policy/rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser-logs]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role_policy_attachment.logs[*]: Creating...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_s*_policy: Creation complete after *s [id=rds-logs-grateful-kid**************************:firehose_s*_policy_eu-west-*]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role_policy_attachment.additional_one[*]: Creation complete after *s [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser-**************************]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role_policy_attachment.logs[*]: Creation complete after *s [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser-**************************]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_lambda_function.this[*]: Creating...
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_lambda_function.this[*]: Still creating... [**s elapsed]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_lambda_function.this[*]: Creation complete after **s [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Read complete after *s [id=*********]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_lambda_policy[*]: Creating...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Creating...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_lambda_policy[*]: Creation complete after *s [id=rds-logs-grateful-kid**************************:firehose_lambda_policy_eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m*s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m*s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m*s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Still creating... [*m**s elapsed]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Creation complete after *m**s [id=arn:aws:firehose:eu-west-*:************:deliverystream/rds-logs-grateful-kid]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.this: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.this: Read complete after *s [id=**********]
module.rds_mysql_logs.module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[*]: Creating...
module.rds_mysql_logs.module.cloudwatch_logs.aws_iam_role_policy.cwl_policy: Creating...
module.rds_mysql_logs.module.cloudwatch_logs.aws_iam_role_policy.cwl_policy: Creation complete after *s [id=rds-logs-grateful-kid**************************:rds-logs-grateful-kid**************************]
module.rds_mysql_logs.module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[*]: Creation complete after *s [id=cwlsf-**********]
╷
│ Error: failure configuring LB attributes: InvalidConfigurationRequest: Access Denied for bucket: honeycomb-tf-integrations-logs-*. Please check S*bucket permission
│       status code: ***, request id: ****a*b*-***c-**f*-*fd*-be*d**f**a*d
│ 
│   with module.alb.aws_lb.this[*],
│   on .terraform/modules/alb/main.tf line *, in resource "aws_lb" "this":
│    *: resource "aws_lb" "this" {
│ 
╵
╷
│ Error: modifying ELB Classic Load Balancer (grateful-kid) attributes: InvalidConfigurationRequest: Access Denied for bucket: honeycomb-tf-integrations-logs-*. Please check S*bucket permission
│       status code: ***, request id: cb**a*b*-****-*bc*-****-**fe**f****c
│ 
│   with module.elb.module.elb.aws_elb.this[*],
│   on .terraform/modules/elb/modules/elb/main.tf line *, in resource "aws_elb" "this":
│    *: resource "aws_elb" "this" {
│ 
╵

terraform-aws-integrations/tests on  bump-test [$!] via 💠 default took **m**s 
```

I added the correct ELB policy to allow putting logs into the s3 bucket


```
terraform-aws-integrations/tests on  bump-test [$!] via 💠 default took **m**s 
❯ eu* terraform apply
var.honeycomb_api_key
  Enter a value: **********************

random_pet.this: Refreshing state... [id=grateful-kid]
module.rds_mysql.random_password.master_password[*]: Refreshing state... [id=none]
module.alb_logs.data.aws_region.current: Reading...
module.cloudwatch_logs.data.aws_region.current: Reading...
module.cloudwatch_logs.module.kfh.data.aws_region.current: Reading...
module.elb_logs.module.s*_processor.data.aws_caller_identity.current: Reading...
module.rds_mysql.module.db_option_group.aws_db_option_group.this[*]: Refreshing state... [id=tf-integrations-rds-mysql-grateful-kid-**************************]
module.alb_logs.module.s*_processor.data.aws_region.current: Reading...
module.rds_mysql.module.db_instance.data.aws_partition.current: Reading...
module.alb_logs.module.s*_processor.data.aws_partition.current: Reading...
module.cloudwatch_logs.module.kfh.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.cloudwatch_logs.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.alb_logs.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.log_group.aws_cloudwatch_log_group.this[*]: Refreshing state... [id=tf-integrations-grateful-kid]
module.alb_logs.module.s*_processor.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql.module.db_instance.data.aws_partition.current: Read complete after *s [id=aws]
module.alb_logs.module.s*_processor.data.aws_partition.current: Read complete after *s [id=aws]
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Reading...
module.firehose_failure_bucket.aws_s*_bucket.this[*]: Refreshing state... [id=honeycomb-tf-integrations-failures-grateful-kid]
module.firehose_failure_bucket.data.aws_partition.current: Reading...
module.rds_mysql.module.db_instance.aws_cloudwatch_log_group.this["slowquery"]: Refreshing state... [id=/aws/rds/instance/tf-integrations-rds-mysql-grateful-kid/slowquery]
module.elb_logs.module.s*_processor.aws_cloudwatch_log_group.lambda[*]: Refreshing state... [id=/aws/lambda/tf-integrations-elb-grateful-kid]
module.firehose_failure_bucket.data.aws_partition.current: Read complete after *s [id=aws]
module.elb_logs.module.s*_processor.data.aws_partition.current: Reading...
data.aws_rds_engine_version.rds_mysql: Reading...
module.rds_mysql.module.db_instance.data.aws_iam_policy_document.enhanced_monitoring: Reading...
module.elb_logs.module.s*_processor.data.aws_partition.current: Read complete after *s [id=aws]
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Read complete after *s [id=*********]
module.rds_mysql.module.db_instance.data.aws_iam_policy_document.enhanced_monitoring: Read complete after *s [id=********]
data.aws_ami.latest: Reading...
module.cloudwatch_metrics.data.aws_iam_policy_document.assume_role: Reading...
module.firehose_failure_bucket.data.aws_caller_identity.current: Reading...
module.cloudwatch_metrics.data.aws_iam_policy_document.assume_role: Read complete after *s [id=**********]
module.firehose_failure_bucket.data.aws_canonical_user_id.this: Reading...
module.elb_logs.module.s*_processor.data.aws_caller_identity.current: Read complete after *s [id=************]
module.cloudwatch_logs.data.aws_caller_identity.current: Reading...
module.firehose_failure_bucket.data.aws_caller_identity.current: Read complete after *s [id=************]
module.cloudwatch_metrics.module.kfh.data.aws_region.current: Reading...
module.cloudwatch_metrics.module.kfh.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Reading...
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Read complete after *s [id=**********]
module.elb_logs.data.aws_region.current: Reading...
module.elb_logs.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.alb_logs.module.s*_processor.data.aws_caller_identity.current: Reading...
module.cloudwatch_logs.data.aws_caller_identity.current: Read complete after *s [id=************]
module.alb_logs.module.log_bucket.data.aws_partition.this: Reading...
module.alb_logs.module.log_bucket.data.aws_partition.this: Read complete after *s [id=aws]
data.aws_s*_bucket.log_bucket: Reading...
module.alb_logs.module.s*_processor.data.aws_caller_identity.current: Read complete after *s [id=************]
module.elb_logs.module.log_bucket.data.aws_partition.this: Reading...
module.elb_logs.module.log_bucket.data.aws_partition.this: Read complete after *s [id=aws]
module.firehose_failure_bucket.data.aws_region.current: Reading...
module.firehose_failure_bucket.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.elb_logs.module.s*_processor.data.aws_region.current: Reading...
module.elb_logs.module.s*_processor.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Reading...
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Read complete after *s [id=*********]
module.rds_mysql.module.db_parameter_group.aws_db_parameter_group.this[*]: Refreshing state... [id=tf-integrations-rds-mysql-grateful-kid-**************************]
data.aws_rds_engine_version.rds_mysql: Read complete after *s [id=*.*.**]
module.elb_logs.module.s*_processor.data.aws_iam_policy_document.assume_role[*]: Reading...
module.elb_logs.module.s*_processor.data.aws_iam_policy_document.assume_role[*]: Read complete after *s [id=**********]
module.alb_logs.module.s*_processor.data.aws_iam_policy_document.assume_role[*]: Reading...
module.alb_logs.module.s*_processor.data.aws_iam_policy_document.assume_role[*]: Read complete after *s [id=**********]
data.aws_vpc.default: Reading...
module.firehose_failure_bucket.data.aws_canonical_user_id.this: Read complete after *s [id=**cc****cab**c*****c**c**c**c********a***f*abbd**d******ada*c***]
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Reading...
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Read complete after *s [id=**********]
module.alb_logs.module.s*_processor.aws_cloudwatch_log_group.lambda[*]: Refreshing state... [id=/aws/lambda/tf-integrations-alb-grateful-kid]
module.cloudwatch_logs.module.kfh.aws_iam_role.firehose_s*_role: Refreshing state... [id=cwlogs-grateful-kid**************************]
module.cloudwatch_metrics.aws_iam_role.this: Refreshing state... [id=cwmetrics-grateful-kid**************************]
module.cloudwatch_metrics.module.kfh.aws_iam_role.firehose_s*_role: Refreshing state... [id=cwmetrics-grateful-kid**************************]
module.elb_logs.module.s*_processor.aws_iam_role.lambda[*]: Refreshing state... [id=tf-integrations-elb-grateful-kid]
module.alb_logs.module.s*_processor.aws_iam_role.lambda[*]: Refreshing state... [id=tf-integrations-alb-grateful-kid]
data.aws_ami.latest: Read complete after *s [id=ami-**c*d*e*cbb*e*ca*]
module.cloudwatch_logs.data.aws_iam_policy_document.assume_role: Reading...
module.cloudwatch_logs.data.aws_iam_policy_document.assume_role: Read complete after *s [id=*********]
module.cloudwatch_logs.aws_iam_role.this: Refreshing state... [id=cwlogs-grateful-kid**************************]
data.aws_s*_bucket.log_bucket: Read complete after *s [id=honeycomb-tf-integrations-logs-*]
module.elb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Reading...
module.elb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Read complete after *s [id=**********]
module.alb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Reading...
module.alb_logs.module.s*_processor.data.aws_iam_policy_document.logs[*]: Read complete after *s [id=**********]
module.elb_logs.module.s*_processor.aws_iam_policy.logs[*]: Refreshing state... [id=arn:aws:iam::************:policy/tf-integrations-elb-grateful-kid-logs]
module.elb_logs.data.aws_arn.s*_bucket: Reading...
module.elb_logs.data.aws_arn.s*_bucket: Read complete after *s [id=arn:aws:s*:::honeycomb-tf-integrations-logs-*]
module.elb_logs.data.aws_iam_policy_document.lambda: Reading...
module.elb_logs.data.aws_iam_policy_document.lambda: Read complete after *s [id=*********]
module.alb_logs.data.aws_iam_policy_document.lambda: Reading...
module.alb_logs.data.aws_iam_policy_document.lambda: Read complete after *s [id=*********]
module.alb_logs.data.aws_arn.s*_bucket: Reading...
module.alb_logs.data.aws_arn.s*_bucket: Read complete after *s [id=arn:aws:s*:::honeycomb-tf-integrations-logs-*]
module.alb_logs.module.s*_processor.aws_iam_policy.logs[*]: Refreshing state... [id=arn:aws:iam::************:policy/tf-integrations-alb-grateful-kid-logs]
module.elb_logs.aws_iam_policy.lambda: Refreshing state... [id=arn:aws:iam::************:policy/terraform-**************************]
module.alb_logs.aws_iam_policy.lambda: Refreshing state... [id=arn:aws:iam::************:policy/terraform-**************************]
module.elb_logs.module.s*_processor.aws_iam_role_policy_attachment.logs[*]: Refreshing state... [id=tf-integrations-elb-grateful-kid-*************************c]
module.elb_logs.module.s*_processor.aws_iam_role_policy_attachment.additional_one[*]: Refreshing state... [id=tf-integrations-elb-grateful-kid-*************************a]
data.aws_vpc.default: Read complete after *s [id=vpc-*ad*bdbc*d****b*a]
data.aws_security_group.default: Reading...
data.aws_subnets.default: Reading...
module.alb_logs.module.s*_processor.aws_iam_role_policy_attachment.logs[*]: Refreshing state... [id=tf-integrations-alb-grateful-kid-*************************d]
aws_security_group.allow_http: Refreshing state... [id=sg-**f**c****ca*****]
module.alb.aws_lb_target_group.main[*]: Refreshing state... [id=arn:aws:elasticloadbalancing:eu-west-*:************:targetgroup/defaul**************************/*fa***b*f*ff*f*f]
module.alb_logs.module.s*_processor.aws_iam_role_policy_attachment.additional_one[*]: Refreshing state... [id=tf-integrations-alb-grateful-kid-*************************b]
module.elb_logs.module.s*_processor.aws_lambda_function.this[*]: Refreshing state... [id=tf-integrations-elb-grateful-kid]
data.aws_security_group.default: Read complete after *s [id=sg-*e*******c******c]
data.aws_subnets.default: Read complete after *s [id=eu-west-*]
module.alb_logs.module.s*_processor.aws_lambda_function.this[*]: Refreshing state... [id=tf-integrations-alb-grateful-kid]
module.rds_mysql.module.db_instance.aws_db_instance.this[*]: Refreshing state... [id=db-QPS***CQL**TJTWF*UCPFEMUJM]
module.alb.aws_lb.this[*]: Refreshing state... [id=arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/app/grateful-kid-sampled-*/***a************]
module.elb.module.elb.aws_elb.this[*]: Refreshing state... [id=grateful-kid]
module.ec*_instances.aws_instance.this[*]: Refreshing state... [id=i-****e*b**ab*f**ac]
module.rds_mysql_logs.data.aws_region.current: Reading...
module.rds_mysql_logs.data.aws_caller_identity.current: Reading...
module.rds_mysql_logs.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_region.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_caller_identity.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_region.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose-assume-role-policy: Read complete after *s [id=*********]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_caller_identity.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_caller_identity.current: Read complete after *s [id=************]
module.rds_mysql_logs.data.aws_caller_identity.current: Read complete after *s [id=************]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_partition.current: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_partition.current: Read complete after *s [id=aws]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_region.current: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role.firehose_s*_role: Refreshing state... [id=rds-logs-grateful-kid**************************]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_region.current: Read complete after *s [id=eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.assume_role: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.assume_role: Read complete after *s [id=*********]
module.rds_mysql_logs.data.aws_iam_policy_document.lambda: Reading...
module.rds_mysql_logs.data.aws_iam_policy_document.lambda: Read complete after *s [id=**********]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_cloudwatch_log_group.lambda[*]: Refreshing state... [id=/aws/lambda/rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_caller_identity.current: Read complete after *s [id=************]
module.rds_mysql_logs.module.cloudwatch_logs.aws_iam_role.this: Refreshing state... [id=rds-logs-grateful-kid**************************]
module.rds_mysql_logs.aws_iam_policy.lambda[*]: Refreshing state... [id=arn:aws:iam::************:policy/terraform-**************************]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.assume_role[*]: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.assume_role[*]: Read complete after *s [id=**********]
module.firehose_failure_bucket.aws_s*_bucket_public_access_block.this[*]: Refreshing state... [id=honeycomb-tf-integrations-failures-grateful-kid]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role.lambda[*]: Refreshing state... [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser]
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.logs[*]: Reading...
module.rds_mysql_logs.module.rds_lambda_transform[*].data.aws_iam_policy_document.logs[*]: Read complete after *s [id=*********]
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Reading...
module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Read complete after *s [id=**********]
module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Refreshing state... [id=arn:aws:firehose:eu-west-*:************:deliverystream/cwlogs-grateful-kid]
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Reading...
module.cloudwatch_metrics.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Read complete after *s [id=**********]
module.cloudwatch_metrics.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Refreshing state... [id=arn:aws:firehose:eu-west-*:************:deliverystream/cwmetrics-grateful-kid]
module.alb_logs.module.log_bucket.aws_lambda_permission.allow["processor"]: Refreshing state... [id=AllowLambdaS*BucketNotification-**************************]
module.elb_logs.module.log_bucket.aws_lambda_permission.allow["processor"]: Refreshing state... [id=AllowLambdaS*BucketNotification-*************************f]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_policy.logs[*]: Refreshing state... [id=arn:aws:iam::************:policy/rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser-logs]
module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_s*_policy: Refreshing state... [id=cwlogs-grateful-kid**************************:firehose_s*_policy_eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_s*_policy_document: Read complete after *s [id=**********]
module.cloudwatch_metrics.module.kfh.aws_iam_role_policy.firehose_s*_policy: Refreshing state... [id=cwmetrics-grateful-kid**************************:firehose_s*_policy_eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_s*_policy: Refreshing state... [id=rds-logs-grateful-kid**************************:firehose_s*_policy_eu-west-*]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role_policy_attachment.additional_one[*]: Refreshing state... [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser-**************************]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_iam_role_policy_attachment.logs[*]: Refreshing state... [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser-**************************]
module.rds_mysql_logs.module.rds_lambda_transform[*].aws_lambda_function.this[*]: Refreshing state... [id=rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser]
module.alb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Refreshing state... [id=honeycomb-tf-integrations-logs-*]
module.elb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Refreshing state... [id=honeycomb-tf-integrations-logs-*]
module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[*]: Refreshing state... [id=cwlsf-**********]
module.cloudwatch_logs.data.aws_iam_policy_document.this: Reading...
module.cloudwatch_metrics.data.aws_iam_policy_document.this: Reading...
module.cloudwatch_logs.data.aws_iam_policy_document.this: Read complete after *s [id=**********]
module.cloudwatch_metrics.data.aws_iam_policy_document.this: Read complete after *s [id=**********]
module.cloudwatch_metrics.aws_cloudwatch_metric_stream.metric-stream: Refreshing state... [id=cwmetrics-grateful-kid]
module.cloudwatch_logs.aws_iam_role_policy.cwl_policy: Refreshing state... [id=cwlogs-grateful-kid**************************:cwlogs-grateful-kid**************************]
module.cloudwatch_metrics.aws_iam_role_policy.this: Refreshing state... [id=cwmetrics-grateful-kid**************************:cwmetrics-grateful-kid**************************]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.data.aws_iam_policy_document.firehose_lambda_policy_document: Read complete after *s [id=*********]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_iam_role_policy.firehose_lambda_policy[*]: Refreshing state... [id=rds-logs-grateful-kid**************************:firehose_lambda_policy_eu-west-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Refreshing state... [id=arn:aws:firehose:eu-west-*:************:deliverystream/rds-logs-grateful-kid]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.this: Reading...
module.rds_mysql_logs.module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[*]: Refreshing state... [id=cwlsf-**********]
module.rds_mysql_logs.module.cloudwatch_logs.data.aws_iam_policy_document.this: Read complete after *s [id=**********]
module.rds_mysql_logs.module.cloudwatch_logs.aws_iam_role_policy.cwl_policy: Refreshing state... [id=rds-logs-grateful-kid**************************:rds-logs-grateful-kid**************************]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # module.alb.aws_lb.this[*] has changed
  ~ resource "aws_lb" "this" {
      + arn                                         = "arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/app/grateful-kid-sampled-*/***a************"
        id                                          = "arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/app/grateful-kid-sampled-*/***a************"
        name                                        = "grateful-kid-sampled-*"
        tags                                        = {
            "Name" = "grateful-kid-sampled-*"
        }
        # (** unchanged attributes hidden)

        # (* unchanged blocks hidden)
    }

  # module.alb_logs.module.s*_processor.aws_lambda_function.this[*] has changed
  ~ resource "aws_lambda_function" "this" {
        id                             = "tf-integrations-alb-grateful-kid"
      ~ last_modified                  = "****-**-**T**:**:**.***+****" -> "****-**-**T**:**:**.***+****"
        tags                           = {
            "Honeycomb Agentless" = "true"
            "Terraform"           = "true"
        }
        # (** unchanged attributes hidden)

        # (* unchanged blocks hidden)
    }

  # module.elb_logs.module.s*_processor.aws_lambda_function.this[*] has changed
  ~ resource "aws_lambda_function" "this" {
        id                             = "tf-integrations-elb-grateful-kid"
      ~ last_modified                  = "****-**-**T**:**:**.***+****" -> "****-**-**T**:**:**.***+****"
        tags                           = {
            "Honeycomb Agentless" = "true"
            "Terraform"           = "true"
        }
        # (** unchanged attributes hidden)

        # (* unchanged blocks hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include
actions to undo or respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.alb.aws_lb.this[*] is tainted, so must be replaced
-/+ resource "aws_lb" "this" {
      ~ arn                                         = "arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/app/grateful-kid-sampled-*/***a************" -> (known after apply)
      ~ arn_suffix                                  = "app/grateful-kid-sampled-*/***a************" -> (known after apply)
      ~ dns_name                                    = "grateful-kid-sampled-*-**********.eu-west-*.elb.amazonaws.com" -> (known after apply)
      - enable_cross_zone_load_balancing            = true -> null
      ~ id                                          = "arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/app/grateful-kid-sampled-*/***a************" -> (known after apply)
        name                                        = "grateful-kid-sampled-*"
        tags                                        = {
            "Name" = "grateful-kid-sampled-*"
        }
      ~ vpc_id                                      = "vpc-*ad*bdbc*d****b*a" -> (known after apply)
      ~ zone_id                                     = "Z**O**XQLNTSW*" -> (known after apply)
        # (** unchanged attributes hidden)

      ~ access_logs {
          + bucket  = "honeycomb-tf-integrations-logs-*"
          ~ enabled = false -> true
          + prefix  = "sampled-*"
        }

      - subnet_mapping {
          - subnet_id = "subnet-**d*f*fb**ea**b**" -> null
        }
      - subnet_mapping {
          - subnet_id = "subnet-**ba**fd***a*b*f*" -> null
        }
      - subnet_mapping {
          - subnet_id = "subnet-***edc*bda*d*cc*d" -> null
        }

        # (* unchanged block hidden)
    }

  # module.alb.aws_lb_listener.frontend_http_tcp[*] will be created
  + resource "aws_lb_listener" "frontend_http_tcp" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = **
      + protocol          = "HTTP"
      + ssl_policy        = (known after apply)
      + tags_all          = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = "arn:aws:elasticloadbalancing:eu-west-*:************:targetgroup/defaul**************************/*fa***b*f*ff*f*f"
          + type             = "forward"
        }
    }

  # module.elb.module.elb.aws_elb.this[*] is tainted, so must be replaced
-/+ resource "aws_elb" "this" {
      ~ arn                         = "arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/grateful-kid" -> (known after apply)
      ~ availability_zones          = [
          - "eu-west-*a",
          - "eu-west-*b",
          - "eu-west-*c",
        ] -> (known after apply)
      ~ cross_zone_load_balancing   = false -> true
      ~ dns_name                    = "grateful-kid-**********.eu-west-*.elb.amazonaws.com" -> (known after apply)
      ~ id                          = "grateful-kid" -> (known after apply)
      ~ instances                   = [] -> (known after apply)
        name                        = "grateful-kid"
      ~ source_security_group       = "************/allow_http-grateful-kid" -> (known after apply)
      ~ source_security_group_id    = "sg-**f**c****ca*****" -> (known after apply)
        tags                        = {
            "Name" = "grateful-kid"
        }
      ~ zone_id                     = "Z**O**XQLNTSW*" -> (known after apply)
        # (* unchanged attributes hidden)

      ~ access_logs {
          + bucket   = "honeycomb-tf-integrations-logs-*"
          ~ enabled  = false -> true
          ~ interval = * -> **
        }

      ~ health_check {
          ~ healthy_threshold   = ** -> *
          ~ target              = "TCP:**" -> "HTTP:**/"
            # (* unchanged attributes hidden)
        }

        # (* unchanged block hidden)
    }

  # module.elb.module.elb_attachment.aws_elb_attachment.this[*] will be created
  + resource "aws_elb_attachment" "this" {
      + elb      = (known after apply)
      + id       = (known after apply)
      + instance = "i-****e*b**ab*f**ac"
    }

  # module.elb_logs.module.log_bucket.aws_s*_bucket_notification.this[*] will be updated in-place
  ~ resource "aws_s*_bucket_notification" "this" {
        id          = "honeycomb-tf-integrations-logs-*"
        # (* unchanged attributes hidden)

      ~ lambda_function {
            id                  = "processor"
          ~ lambda_function_arn = "arn:aws:lambda:eu-west-*:************:function:tf-integrations-alb-grateful-kid" -> "arn:aws:lambda:eu-west-*:************:function:tf-integrations-elb-grateful-kid"
            # (* unchanged attributes hidden)
        }
    }

  # module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream will be updated in-place
  ~ resource "aws_kinesis_firehose_delivery_stream" "http_stream" {
        id             = "arn:aws:firehose:eu-west-*:************:deliverystream/rds-logs-grateful-kid"
        name           = "rds-logs-grateful-kid"
        tags           = {}
        # (* unchanged attributes hidden)

      ~ http_endpoint_configuration {
            name               = "honeycomb"
            # (* unchanged attributes hidden)

          ~ processing_configuration {
                # (* unchanged attribute hidden)

              ~ processors {
                    # (* unchanged attribute hidden)

                  ~ parameters {
                      ~ parameter_name  = "LambdaArn" -> "BufferIntervalInSeconds"
                      ~ parameter_value = "arn:aws:lambda:eu-west-*:************:function:rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser:$LATEST" -> "**"
                    }
                  ~ parameters {
                      ~ parameter_name  = "BufferIntervalInSeconds" -> "LambdaArn"
                      ~ parameter_value = "**" -> "arn:aws:lambda:eu-west-*:************:function:rds-logs-grateful-kid-honeycomb-rds-mysql-log-parser:$LATEST"
                    }

                    # (* unchanged block hidden)
                }
            }

            # (* unchanged blocks hidden)
        }

        # (* unchanged block hidden)
    }

Plan: * to add, * to change, * to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.elb.module.elb.aws_elb.this[*]: Destroying... [id=grateful-kid]
module.alb.aws_lb.this[*]: Destroying... [id=arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/app/grateful-kid-sampled-*/***a************]
module.elb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Modifying... [id=honeycomb-tf-integrations-logs-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Modifying... [id=arn:aws:firehose:eu-west-*:************:deliverystream/rds-logs-grateful-kid]
module.elb_logs.module.log_bucket.aws_s*_bucket_notification.this[*]: Modifications complete after *s [id=honeycomb-tf-integrations-logs-*]
module.rds_mysql_logs.module.cloudwatch_logs.module.kfh.aws_kinesis_firehose_delivery_stream.http_stream: Modifications complete after *s [id=arn:aws:firehose:eu-west-*:************:deliverystream/rds-logs-grateful-kid]
module.elb.module.elb.aws_elb.this[*]: Destruction complete after *s
module.elb.module.elb.aws_elb.this[*]: Creating...
module.alb.aws_lb.this[*]: Destruction complete after *s
module.alb.aws_lb.this[*]: Creating...
module.elb.module.elb.aws_elb.this[*]: Creation complete after *s [id=grateful-kid]
module.elb.module.elb_attachment.aws_elb_attachment.this[*]: Creating...
module.elb.module.elb_attachment.aws_elb_attachment.this[*]: Creation complete after *s [id=grateful-kid-**************************]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m*s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m**s elapsed]
module.alb.aws_lb.this[*]: Still creating... [*m*s elapsed]
module.alb.aws_lb.this[*]: Creation complete after *m*s [id=arn:aws:elasticloadbalancing:eu-west-*:************:loadbalancer/app/grateful-kid-sampled-*/ed*******a**b***]
module.alb.aws_lb_listener.frontend_http_tcp[*]: Creating...
module.alb.aws_lb_listener.frontend_http_tcp[*]: Creation complete after *s [id=arn:aws:elasticloadbalancing:eu-west-*:************:listener/app/grateful-kid-sampled-*/ed*******a**b***/*****dd**fb*c***]
╷
│ Warning: cleaning up ELB Classic Load Balancer (grateful-kid) ENIs: * error occurred:
│       * detaching EC* Network Interface (eni-****b*d*e**a*d***/eni-attach-**daf*e*a*b**c*fb): AuthFailure: You do not have permission to access the specified resource.
│       status code: ***, request id: e*f*****-*e*d-*b**-a**a-ae*bfec**c**
│ 
│ 
│ 
│ 
╵

Apply complete! Resources: 4 added, 2 changed, 2 destroyed.

```