### PR TITLE
fix: pin dependant modules to reduce churn

### DIFF
--- a/modules/rds-logs/USAGE.md
+++ b/modules/rds-logs/USAGE.md
@@ -17,7 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudwatch_logs"></a> [cloudwatch\_logs](#module\_cloudwatch\_logs) | ../cloudwatch-logs | n/a |
-| <a name="module_rds_lambda_transform"></a> [rds\_lambda\_transform](#module\_rds\_lambda\_transform) | terraform-aws-modules/lambda/aws | ~> 4.2 |
+| <a name="module_rds_lambda_transform"></a> [rds\_lambda\_transform](#module\_rds\_lambda\_transform) | terraform-aws-modules/lambda/aws | 4.18.0 |
 
 ## Resources
 

--- a/modules/rds-logs/main.tf
+++ b/modules/rds-logs/main.tf
@@ -29,7 +29,7 @@ resource "aws_iam_policy" "lambda" {
 
 module "rds_lambda_transform" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 4.2"
+  version = "4.18.0"
 
   count = local.enable_lambda_transform ? 1 : 0
 

--- a/modules/s3-logfile/USAGE.md
+++ b/modules/s3-logfile/USAGE.md
@@ -16,8 +16,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-aws-modules/s3-bucket/aws//modules/notification | ~> 3.0 |
-| <a name="module_s3_processor"></a> [s3\_processor](#module\_s3\_processor) | terraform-aws-modules/lambda/aws | ~> 4.2 |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-aws-modules/s3-bucket/aws//modules/notification | 3.15.2 |
+| <a name="module_s3_processor"></a> [s3\_processor](#module\_s3\_processor) | terraform-aws-modules/lambda/aws | 4.18.0 |
 
 ## Resources
 

--- a/modules/s3-logfile/main.tf
+++ b/modules/s3-logfile/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "lambda" {
 
 module "s3_processor" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 4.2"
+  version = "4.18.0"
 
   function_name = var.name
   description   = "Parses LB access logs from S3, sending them to Honeycomb as structured events"
@@ -80,7 +80,7 @@ module "s3_processor" {
 
 module "log_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws//modules/notification"
-  version = "~> 3.0"
+  version = "3.15.2"
 
   bucket = data.aws_arn.s3_bucket.resource
 


### PR DESCRIPTION
## Which problem is this PR solving?

Reports of surprise upgrades (and with them the possibility of dependency conflicts) due to fuzzy pins means we should pin to the latest of these versions (which, are fairly behind, but this should hopefully provide a more consistent experience).