### PR TITLE
maint: Remove OpenTelemetry 0.7 data format

### DIFF
--- a/modules/cloudwatch-metrics/variables.tf
+++ b/modules/cloudwatch-metrics/variables.tf
@@ -148,7 +148,7 @@ variable "output_format" {
   description = "Output format of metrics. You should probably not modify this value; the default format is supported, but others may not be."
 
   validation {
-    condition     = contains(["json", "opentelemetry0.7", "opentelemetry1.0"], var.output_format)
+    condition     = contains(["json", "opentelemetry1.0"], var.output_format)
     error_message = "Not an allowed output format."
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The OpenTelemetry 0.7 data format is old and contains breaking changes compared the newer 1.0 and later versions. This PR removes using that data format as a valid option.

## Short description of the changes

- Remove opentelemetry 0.7 as a valid data format

## How to verify that this has the expected result

It's no longer possible to select OpenTelemtry 0.7 as the data format for CloudWatch metrics.