### PR TITLE
feat: Allow resource names to be overridden when installing top-level module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 *.tfstate
 *.tfstate.backup
 terraform.tfvars
+
+# Temporary output directory
+tempouts/

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ module "failure_bucket" {
 
 module "cloudwatch_logs" {
   source = "./modules/cloudwatch-logs"
-  name   = "honeycomb-cloudwatch-logs"
+  name   = var.cloudwatch_logs_name
 
   count                 = length(var.cloudwatch_log_groups) > 0 ? 1 : 0
   cloudwatch_log_groups = var.cloudwatch_log_groups
@@ -45,7 +45,7 @@ module "cloudwatch_logs" {
 
 module "rds_logs" {
   source = "./modules/rds-logs"
-  name   = "honeycomb-rds-cloudwatch-logs"
+  name   = var.rds_logs_name
 
   count = var.enable_rds_logs ? 1 : 0
 
@@ -63,7 +63,7 @@ module "rds_logs" {
 
 module "cloudwatch_metrics" {
   source = "./modules/cloudwatch-metrics"
-  name   = "honeycomb-cloudwatch-metrics"
+  name   = var.cloudwatch_metrics_name
 
   count = var.enable_cloudwatch_metrics ? 1 : 0
 
@@ -78,7 +78,7 @@ module "cloudwatch_metrics" {
 
 module "s3_logfile" {
   source = "./modules/s3-logfile"
-  name   = "honeycomb-s3-logfile"
+  name   = var.s3_logfile_name
 
   count = var.s3_bucket_arn != "" ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,27 @@ variable "vpc_subnet_ids" {
   description = "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets."
   default     = null
 }
+
+variable "cloudwatch_logs_name" {
+  type        = string
+  description = "Name for the CloudWatch Logs integration resources"
+  default     = "honeycomb-cloudwatch-logs"
+}
+
+variable "rds_logs_name" {
+  type        = string
+  description = "Name for the RDS Logs integration resources"
+  default     = "honeycomb-rds-cloudwatch-logs"
+}
+
+variable "cloudwatch_metrics_name" {
+  type        = string
+  description = "Name for the CloudWatch Metrics integration resources"
+  default     = "honeycomb-cloudwatch-metrics"
+}
+
+variable "s3_logfile_name" {
+  type        = string
+  description = "Name for the S3 Logfile integration resources"
+  default     = "honeycomb-s3-logfile"
+}


### PR DESCRIPTION
## Fix violation of IAM naming constraints with postgresql in v1.3.1

Fixes the following error when using "postgresql" as db_engine:
```
Error: expected length of name to be in the range (1 - 64), got honeycomb-rds-cloudwatch-logs-honeycomb-rds-postgresql-log-parser

  with module.honeycomb-aws-integrations.module.rds_logs[0].module.rds_lambda_transform[0].aws_iam_role.lambda[0],
  on .terraform/modules/honeycomb-aws-integrations.rds_logs.rds_lambda_transform/iam.tf line 97, in resource "aws_iam_role" "lambda":
  97:   name                  = local.role_name
```

## Reproduction

To reproduce the original error:
1. Deploy the main wrapper module using v1.3.1 as described in documentation [here](https://registry.terraform.io/modules/honeycombio/integrations/aws/latest/examples/complete).
2. Set `rds_db_engine = "postgresql"`.
3. Observe IAM naming constraints being exceeded on first deployment

## Solution

Extracted hardcoded resource names to allow configurable variables with backward-compatible defaults.

## Changes

Extracted hardcoded "honeycomb-..." resource names to variables with configurable defaults:
- `cloudwatch_logs_name`
- `rds_logs_name`
- `cloudwatch_metrics_name`
- `s3_logfile_name`