### PR TITLE
maint: Limit hashicorp/aws provider to 5.x versions

### DIFF
--- a/modules/cloudwatch-logs/versions.tf
+++ b/modules/cloudwatch-logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/cloudwatch-metrics/versions.tf
+++ b/modules/cloudwatch-metrics/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/kinesis-firehose-honeycomb/versions.tf
+++ b/modules/kinesis-firehose-honeycomb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/rds-logs/versions.tf
+++ b/modules/rds-logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/s3-logfile/versions.tf
+++ b/modules/s3-logfile/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/tests/versions.tf
+++ b/tests/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
 
     random = {


### PR DESCRIPTION
## Which problem is this PR solving?

The latest 6.x hashicorp/aws provider versions does not provide all valid platforms (eg linux_amd64 or darwin_arm64). This PR limits the modules to to use version 5.X of the provider.

## Short description of the changes

- Update each module to use the version limiter definition `~>` instead of normal `>=`
