### PR TITLE
feat(kinesis): add App Runner OpenTelemetry collector for multiplexing

### DIFF
--- a/modules/cloudwatch-metrics/outputs.tf
+++ b/modules/cloudwatch-metrics/outputs.tf
@@ -5,3 +5,13 @@ output "cloudwatch_metric_stream_arn" {
 output "cloudwatch_metric_stream_name" {
   value = aws_cloudwatch_metric_stream.metric-stream.name
 }
+
+output "otel_collector_service_url" {
+  value = module.kfh.otel_collector_service_url
+  description = "The URL of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
+}
+
+output "otel_collector_service_arn" {
+  value = module.kfh.otel_collector_service_arn
+  description = "The ARN of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
+}

--- a/modules/cloudwatch-metrics/outputs.tf
+++ b/modules/cloudwatch-metrics/outputs.tf
@@ -7,11 +7,11 @@ output "cloudwatch_metric_stream_name" {
 }
 
 output "otel_collector_service_url" {
-  value = module.kfh.otel_collector_service_url
+  value       = module.kfh.otel_collector_service_url
   description = "The URL of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }
 
 output "otel_collector_service_arn" {
-  value = module.kfh.otel_collector_service_arn
+  value       = module.kfh.otel_collector_service_arn
   description = "The ARN of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }

--- a/modules/cloudwatch-metrics/outputs.tf
+++ b/modules/cloudwatch-metrics/outputs.tf
@@ -7,11 +7,11 @@ output "cloudwatch_metric_stream_name" {
 }
 
 output "otel_collector_service_url" {
-  value       = module.kfh.otel_collector_service_url
+  value       = nonsensitive(module.kfh.otel_collector_service_url)
   description = "The URL of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }
 
 output "otel_collector_service_arn" {
-  value       = module.kfh.otel_collector_service_arn
+  value       = nonsensitive(module.kfh.otel_collector_service_arn)
   description = "The ARN of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }

--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -23,7 +23,7 @@ locals {
   compact_config = "receivers:\n  awsfirehose:\n    endpoint: 0.0.0.0:4433\n    record_type: otlp_v1\nexporters:\n${join("\n", [for idx, dest in local.destinations : "  otlphttp/${idx}:\n    endpoint: ${dest.honeycomb_api_host}/v1/metrics\n    headers:\n      x-honeycomb-team: ${dest.honeycomb_api_key}\n      x-honeycomb-dataset: ${dest.honeycomb_dataset_name}"])}\nprocessors:\n  batch:\n    timeout: 300s\n    send_batch_size: 100000\nservice:\n  pipelines:\n    metrics:\n      receivers: [awsfirehose]\n      processors: [batch]\n      exporters: [${join(", ", [for idx, dest in local.destinations : "otlphttp/${idx}"])}]"
 
   collector_env_vars = {
-    OTEL_CONFIG = local.compact_config
+    OTEL_CONFIG = jsonencode(local.compact_config)
   }
 }
 

--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -67,11 +67,6 @@ locals {
 }
 
 moved {
-  from = aws_kinesis_firehose_delivery_stream.http_stream[0]
-  to   = aws_kinesis_firehose_delivery_stream.stream
-}
-
-moved {
   from = aws_kinesis_firehose_delivery_stream.http_stream
   to   = aws_kinesis_firehose_delivery_stream.stream
 }

--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -126,7 +126,7 @@ resource "aws_apprunner_service" "otel_collector" {
         runtime_environment_variables = {
           OTEL_CONFIG = jsonencode(local.otel_config)
         }
-        start_command = "/honeycomb-opentelemetry-collector --config env:OTEL_CONFIG"
+        start_command = "--config env:OTEL_CONFIG"
       }
       image_identifier      = "public.ecr.aws/honeycombio/honeycomb-opentelemetry-collector:v0.0.19"
       image_repository_type = "ECR_PUBLIC"

--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -80,6 +80,7 @@ resource "aws_apprunner_service" "otel_collector" {
   service_name = "${var.name}-otel-collector"
 
   source_configuration {
+    auto_deployments_enabled = false
     image_repository {
       image_configuration {
         port                          = "4433"

--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -145,6 +145,10 @@ resource "aws_apprunner_service" "otel_collector" {
     }
   }
 
+  observability_configuration {
+    observability_enabled = false
+  }
+
   tags = var.tags
 }
 

--- a/modules/kinesis-firehose-honeycomb/outputs.tf
+++ b/modules/kinesis-firehose-honeycomb/outputs.tf
@@ -3,11 +3,11 @@ output "kinesis_firehose_delivery_stream_arn" {
 }
 
 output "otel_collector_service_url" {
-  value       = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].service_url : null
+  value       = length(local.destinations) > 1 ? nonsensitive(aws_apprunner_service.otel_collector[0].service_url) : null
   description = "The URL of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }
 
 output "otel_collector_service_arn" {
-  value       = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].arn : null
+  value       = length(local.destinations) > 1 ? nonsensitive(aws_apprunner_service.otel_collector[0].arn) : null
   description = "The ARN of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }

--- a/modules/kinesis-firehose-honeycomb/outputs.tf
+++ b/modules/kinesis-firehose-honeycomb/outputs.tf
@@ -1,5 +1,5 @@
 output "kinesis_firehose_delivery_stream_arn" {
-  value = length(local.destinations) == 1 ? aws_kinesis_firehose_delivery_stream.http_stream[0].arn : aws_kinesis_firehose_delivery_stream.collector_stream[0].arn
+  value = aws_kinesis_firehose_delivery_stream.stream.arn
 }
 
 output "otel_collector_service_url" {

--- a/modules/kinesis-firehose-honeycomb/outputs.tf
+++ b/modules/kinesis-firehose-honeycomb/outputs.tf
@@ -3,11 +3,11 @@ output "kinesis_firehose_delivery_stream_arn" {
 }
 
 output "otel_collector_service_url" {
-  value = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].service_url : null
+  value       = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].service_url : null
   description = "The URL of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }
 
 output "otel_collector_service_arn" {
-  value = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].arn : null
+  value       = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].arn : null
   description = "The ARN of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }

--- a/modules/kinesis-firehose-honeycomb/outputs.tf
+++ b/modules/kinesis-firehose-honeycomb/outputs.tf
@@ -1,3 +1,13 @@
 output "kinesis_firehose_delivery_stream_arn" {
-  value = aws_kinesis_firehose_delivery_stream.http_stream[0].arn
+  value = length(local.destinations) == 1 ? aws_kinesis_firehose_delivery_stream.http_stream[0].arn : aws_kinesis_firehose_delivery_stream.collector_stream[0].arn
+}
+
+output "otel_collector_service_url" {
+  value = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].service_url : null
+  description = "The URL of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
+}
+
+output "otel_collector_service_arn" {
+  value = length(local.destinations) > 1 ? aws_apprunner_service.otel_collector[0].arn : null
+  description = "The ARN of the OpenTelemetry collector App Runner service (only available when using multiple destinations)"
 }

--- a/modules/kinesis-firehose-honeycomb/variables.tf
+++ b/modules/kinesis-firehose-honeycomb/variables.tf
@@ -138,3 +138,9 @@ variable "otel_access_key" {
   default     = ""
   sensitive   = true
 }
+
+variable "otel_collector_version" {
+  type        = string
+  description = "The version tag of the Honeycomb OpenTelemetry collector image to use."
+  default     = "v0.0.19"
+}

--- a/modules/kinesis-firehose-honeycomb/variables.tf
+++ b/modules/kinesis-firehose-honeycomb/variables.tf
@@ -131,3 +131,10 @@ variable "tags" {
   default     = {}
   description = "A map of tags to apply to resources created by this module."
 }
+
+variable "otel_access_key" {
+  type        = string
+  description = "Access key for OpenTelemetry collector awsfirehose receiver authentication. Generated randomly if not provided."
+  default     = ""
+  sensitive   = true
+}

--- a/tests/cloudwatch-metrics.tf
+++ b/tests/cloudwatch-metrics.tf
@@ -91,11 +91,11 @@ module "cloudwatch_metrics_multi" {
 
 # Outputs to verify App Runner service creation
 output "cwm_multi_otel_collector_url" {
-  value = module.cloudwatch_metrics_multi.otel_collector_service_url
+  value       = module.cloudwatch_metrics_multi.otel_collector_service_url
   description = "Should be non-null when using multiple destinations"
 }
 
 output "cwm_multi_otel_collector_arn" {
-  value = module.cloudwatch_metrics_multi.otel_collector_service_arn  
+  value       = module.cloudwatch_metrics_multi.otel_collector_service_arn
   description = "Should be non-null when using multiple destinations"
 }

--- a/tests/cloudwatch-metrics.tf
+++ b/tests/cloudwatch-metrics.tf
@@ -91,11 +91,11 @@ module "cloudwatch_metrics_multi" {
 
 # Outputs to verify App Runner service creation
 output "cwm_multi_otel_collector_url" {
-  value       = module.cloudwatch_metrics_multi.otel_collector_service_url
+  value       = nonsensitive(module.cloudwatch_metrics_multi.otel_collector_service_url)
   description = "Should be non-null when using multiple destinations"
 }
 
 output "cwm_multi_otel_collector_arn" {
-  value       = module.cloudwatch_metrics_multi.otel_collector_service_arn
+  value       = nonsensitive(module.cloudwatch_metrics_multi.otel_collector_service_arn)
   description = "Should be non-null when using multiple destinations"
 }

--- a/tests/cloudwatch-metrics.tf
+++ b/tests/cloudwatch-metrics.tf
@@ -56,3 +56,46 @@ module "cloudwatch_metrics" {
     }
   ]
 }
+
+# Test with three destinations to verify App Runner multiplexing
+module "cloudwatch_metrics_multi" {
+  source = "../modules/cloudwatch-metrics"
+
+  name = "cwm-multi-${random_pet.this.id}"
+
+  honeycomb_api_host     = var.honeycomb_api_host
+  honeycomb_api_key      = var.honeycomb_api_key
+  honeycomb_dataset_name = "cloudwatch-metrics-primary"
+  additional_destinations = [
+    {
+      honeycomb_dataset_name = "cloudwatch-metrics-secondary"
+      honeycomb_api_host     = var.honeycomb_api_host
+      honeycomb_api_key      = var.honeycomb_api_key
+    },
+    {
+      honeycomb_dataset_name = "cloudwatch-metrics-tertiary"
+      honeycomb_api_host     = var.honeycomb_api_host
+      honeycomb_api_key      = var.honeycomb_api_key
+    }
+  ]
+
+  s3_failure_bucket_arn = module.firehose_failure_bucket.s3_bucket_arn
+
+  include_filters = [
+    {
+      namespace    = "AWS/RDS"
+      metric_names = []
+    }
+  ]
+}
+
+# Outputs to verify App Runner service creation
+output "cwm_multi_otel_collector_url" {
+  value = module.cloudwatch_metrics_multi.otel_collector_service_url
+  description = "Should be non-null when using multiple destinations"
+}
+
+output "cwm_multi_otel_collector_arn" {
+  value = module.cloudwatch_metrics_multi.otel_collector_service_arn  
+  description = "Should be non-null when using multiple destinations"
+}

--- a/tests/kinesis-firehose.tf
+++ b/tests/kinesis-firehose.tf
@@ -20,7 +20,7 @@ module "kinesis_firehose_multi" {
   honeycomb_api_host     = var.honeycomb_api_host
   honeycomb_api_key      = var.honeycomb_api_key
   honeycomb_dataset_name = "kinesis-primary"
-  
+
   additional_destinations = [
     {
       honeycomb_dataset_name = "kinesis-secondary"
@@ -47,11 +47,11 @@ output "multi_destination_stream_arn" {
 }
 
 output "otel_collector_service_url" {
-  value = module.kinesis_firehose_multi.otel_collector_service_url
+  value       = module.kinesis_firehose_multi.otel_collector_service_url
   description = "Should be non-null for multi-destination scenario"
 }
 
 output "otel_collector_service_arn" {
-  value = module.kinesis_firehose_multi.otel_collector_service_arn
+  value       = module.kinesis_firehose_multi.otel_collector_service_arn
   description = "Should be non-null for multi-destination scenario"
 }

--- a/tests/kinesis-firehose.tf
+++ b/tests/kinesis-firehose.tf
@@ -1,0 +1,57 @@
+# Test single destination (direct delivery)
+module "kinesis_firehose_single" {
+  source = "../modules/kinesis-firehose-honeycomb"
+
+  name = "kfh-single-${random_pet.this.id}"
+
+  honeycomb_api_host     = var.honeycomb_api_host
+  honeycomb_api_key      = var.honeycomb_api_key
+  honeycomb_dataset_name = "kinesis-single"
+
+  s3_failure_bucket_arn = module.firehose_failure_bucket.s3_bucket_arn
+}
+
+# Test multiple destinations (App Runner multiplexing)
+module "kinesis_firehose_multi" {
+  source = "../modules/kinesis-firehose-honeycomb"
+
+  name = "kfh-multi-${random_pet.this.id}"
+
+  honeycomb_api_host     = var.honeycomb_api_host
+  honeycomb_api_key      = var.honeycomb_api_key
+  honeycomb_dataset_name = "kinesis-primary"
+  
+  additional_destinations = [
+    {
+      honeycomb_dataset_name = "kinesis-secondary"
+      honeycomb_api_host     = var.honeycomb_api_host
+      honeycomb_api_key      = var.honeycomb_api_key
+    },
+    {
+      honeycomb_dataset_name = "kinesis-tertiary"
+      honeycomb_api_host     = var.honeycomb_api_host
+      honeycomb_api_key      = var.honeycomb_api_key
+    }
+  ]
+
+  s3_failure_bucket_arn = module.firehose_failure_bucket.s3_bucket_arn
+}
+
+# Output to verify App Runner service is created for multi-destination
+output "single_destination_stream_arn" {
+  value = module.kinesis_firehose_single.kinesis_firehose_delivery_stream_arn
+}
+
+output "multi_destination_stream_arn" {
+  value = module.kinesis_firehose_multi.kinesis_firehose_delivery_stream_arn
+}
+
+output "otel_collector_service_url" {
+  value = module.kinesis_firehose_multi.otel_collector_service_url
+  description = "Should be non-null for multi-destination scenario"
+}
+
+output "otel_collector_service_arn" {
+  value = module.kinesis_firehose_multi.otel_collector_service_arn
+  description = "Should be non-null for multi-destination scenario"
+}

--- a/tests/kinesis-firehose.tf
+++ b/tests/kinesis-firehose.tf
@@ -39,19 +39,19 @@ module "kinesis_firehose_multi" {
 
 # Output to verify App Runner service is created for multi-destination
 output "single_destination_stream_arn" {
-  value = module.kinesis_firehose_single.kinesis_firehose_delivery_stream_arn
+  value = nonsensitive(module.kinesis_firehose_single.kinesis_firehose_delivery_stream_arn)
 }
 
 output "multi_destination_stream_arn" {
-  value = module.kinesis_firehose_multi.kinesis_firehose_delivery_stream_arn
+  value = nonsensitive(module.kinesis_firehose_multi.kinesis_firehose_delivery_stream_arn)
 }
 
 output "otel_collector_service_url" {
-  value       = module.kinesis_firehose_multi.otel_collector_service_url
+  value       = nonsensitive(module.kinesis_firehose_multi.otel_collector_service_url)
   description = "Should be non-null for multi-destination scenario"
 }
 
 output "otel_collector_service_arn" {
-  value       = module.kinesis_firehose_multi.otel_collector_service_arn
+  value       = nonsensitive(module.kinesis_firehose_multi.otel_collector_service_arn)
   description = "Should be non-null for multi-destination scenario"
 }


### PR DESCRIPTION
## Summary
Add support for multiplexing Kinesis Firehose metrics to multiple Honeycomb destinations using an App Runner service with the Honeycomb OpenTelemetry collector. This is the correct way to solve #89, the previous implementation did not actually work.

## Key Features
- Smart routing logic: single destination uses direct delivery, multiple destinations automatically use App Runner multiplexing
- Uses `public.ecr.aws/honeycombio/honeycomb-opentelemetry-collector:v0.0.19` 
- Configures awsfirehose receiver with `otlp_v1` encoding on port 4433
- Dynamic OTLP HTTP exporters for each destination with proper Honeycomb headers
- Environment variable-based configuration injection via `OTEL_CONFIG`
- Custom start command: `/honeycomb-opentelemetry-collector --config env:OTEL_CONFIG`
- Maintains full backward compatibility with existing single destination deployments

## Test plan
- [x] Verify single destination deployments continue to work as before
- [x] Test multiple destination configuration creates App Runner service
- [x] Validate OpenTelemetry collector configuration is properly injected
- [ ] Confirm metrics are multiplexed to all configured Honeycomb destinations
- [x] Check App Runner service scaling and health

🤖 Generated with [Claude Code](https://claude.ai/code)