### PR TITLE
Add cloudwatch metrics filters variable to top level module

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -37,6 +37,22 @@ module "honeycomb-aws-integrations" {
 
   # aws metrics integration
   # enable_cloudwatch_metrics = true
+  # Only stream specific EC2 metrics and all ELB metrics to Honeycomb
+  # cloudwatch_metrics_include_filters = [
+  #   {
+  #     namespace = "AWS/EC2"
+  #     metric_names = [
+  #       "CPUUtilization",
+  #       "DiskWriteOps",
+  #       "NetworkIn",
+  #       "NetworkOut"
+  #     ]
+  #   },
+  #   {
+  #     namespace    = "AWS/ELB"
+  #     metric_names = [] # include all metrics for this namespace
+  #   }
+  # ]
 
   # s3 logfile - alb access logs
   s3_bucket_arn  = var.s3_bucket_arn

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -16,6 +16,22 @@ module "honeycomb-aws-integrations" {
 
   # aws metrics integration
   # enable_cloudwatch_metrics = true
+  # Only stream specific EC2 metrics and all ELB metrics to Honeycomb
+  # cloudwatch_metrics_include_filters = [
+  #   {
+  #     namespace = "AWS/EC2"
+  #     metric_names = [
+  #       "CPUUtilization",
+  #       "DiskWriteOps",
+  #       "NetworkIn",
+  #       "NetworkOut"
+  #     ]
+  #   },
+  #   {
+  #     namespace    = "AWS/ELB"
+  #     metric_names = [] # include all metrics for this namespace
+  #   }
+  # ]
 
   # s3 logfile - alb access logs
   s3_bucket_arn  = var.s3_bucket_arn

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,9 @@ module "cloudwatch_metrics" {
   honeycomb_api_key      = var.honeycomb_api_key
   honeycomb_dataset_name = "cloudwatch-metrics"
 
+  include_filters = var.cloudwatch_metrics_include_filters
+  exclude_filters = var.cloudwatch_metrics_exclude_filters
+
   s3_failure_bucket_arn = module.failure_bucket.s3_bucket_arn
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -207,8 +207,35 @@ variable "cloudwatch_metrics_name" {
   default     = "honeycomb-cloudwatch-metrics"
 }
 
+variable "cloudwatch_metrics_include_filters" {
+  type = list(object({
+    namespace    = string
+    metric_names = list(string)
+  }))
+  default     = []
+  description = <<EOH
+An optional list of inclusive CloudWatch Metric filters. If set, we'll only stream metrics matching these namespace and metric names.
+Pass an empty list (`[]`) to `metric_names` to include all metrics for the namespace.
+Mutually exclusive with exclude filters.
+EOH
+}
+
+variable "cloudwatch_metrics_exclude_filters" {
+  type = list(object({
+    namespace    = string
+    metric_names = list(string)
+  }))
+  default     = []
+  description = <<EOH
+An optional list of exclusive CloudWatch Metric filters. If set, we'll only stream metrics that do not match these namespace and metric names.
+Pass an empty list (`[]`) to `metric_names` to exclude all metrics for the namespace.
+Mutually exclusive with include filters.
+EOH
+}
+
 variable "s3_logfile_name" {
   type        = string
   description = "Name for the S3 Logfile integration resources"
   default     = "honeycomb-s3-logfile"
 }
+


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The cloudwatch metrics module supports a filter for including and a filter for excluding metrics by namesapce and metric names.  These variables were not passed through from the top level chart. 

## Short description of the changes

Adds the variables to the top level chart so they can be set and passed through. 

## How to verify that this has the expected result
