### PR TITLE
maint(deps): bump default honeycomb-otelcol image to v0.0.29

### DIFF
--- a/modules/kinesis-firehose-honeycomb/variables.tf
+++ b/modules/kinesis-firehose-honeycomb/variables.tf
@@ -142,5 +142,5 @@ variable "otel_access_key" {
 variable "otel_collector_version" {
   type        = string
   description = "The version tag of the Honeycomb OpenTelemetry collector image to use."
-  default     = "v0.0.19"
+  default     = "v0.0.29"
 }


### PR DESCRIPTION
## Summary

The Firehose multi-destination path (added in #95) runs the Honeycomb
collector distro in App Runner. The default `otel_collector_version` was
pinned to `v0.0.19` — the first tag that included the `awsfirehose`
receiver (Sept 2025). `v0.0.29` is current (Apr 2026) and picks up
receiver/exporter fixes shipped since.

This is just the dependency bump. End-to-end verification of the
multi-destination data flow (the unchecked checkbox from the original
PR's test plan) will happen in a follow-up by exercising it from the
infra repo and watching CWMS → Firehose → App Runner → Honeycomb in
real traffic.

## Test plan

- [ ] `terraform plan` against an existing single-destination
  deployment shows no diff (image isn't used in that path).
- [ ] `terraform plan` against a multi-destination deployment shows the
  App Runner service updating its image tag from `v0.0.19` to `v0.0.29`.
- [ ] Apply in dogfood, confirm App Runner reaches `RUNNING`, and
  confirm metrics arrive at every configured Honeycomb dataset.

https://claude.ai/code/session_01HBqb8GZiq4hSJjtKytP2i7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBqb8GZiq4hSJjtKytP2i7)_