### PR TITLE
fix: bump terraform-aws-modules/lambda to 8.8.0 for AWS provider v6 compatibility

### DIFF
--- a/modules/rds-logs/main.tf
+++ b/modules/rds-logs/main.tf
@@ -29,7 +29,7 @@ resource "aws_iam_policy" "lambda" {
 
 module "rds_lambda_transform" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "4.18.0"
+  version = "8.8.0"
 
   count = local.enable_lambda_transform ? 1 : 0
 

--- a/modules/rds-logs/versions.tf
+++ b/modules/rds-logs/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {

--- a/modules/s3-logfile/main.tf
+++ b/modules/s3-logfile/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "lambda" {
 
 module "s3_processor" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "4.18.0"
+  version = "8.8.0"
 
   function_name = var.name
   description   = "Parses LB access logs from S3, sending them to Honeycomb as structured events"

--- a/modules/s3-logfile/versions.tf
+++ b/modules/s3-logfile/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Which problem is this PR solving?

honeycombio/terraform-aws-integrations v2.0.0 moved to v6.0+ of the AWS provider, but our `rds-logs` and `s3-logfile` modules kept a precise pin on the lambda module (`= "4.18.0"`) that references a property (`data.aws_region.current.name`) removed in AWS v6 . Errors ensue.

The fix for the lambda module was when it updated to AWS provider v6+ in [v8.0.0](https://github.com/terraform-aws-modules/terraform-aws-lambda/releases/tag/v8.0.0) (and terraform minumum version v1.5.7 in [v8.0.1](https://github.com/terraform-aws-modules/terraform-aws-lambda/releases/tag/v8.0.1))

## Short description of the changes

`rds-logs` and `s3-logfile` both 
- update to lambda module `version = "8.8.0"`
- minimum terraform `required_version = ">= 1.5.7"`

## How to verify that this has the expected result

CI is working again. "Test Terraform Modules" passes with no errors about lambda module using a property that doesn't exist anymore.