### PR TITLE
ci: upgrade actions used in workflows

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -10,8 +10,8 @@ jobs:
   terraform-fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: hashicorp/setup-terraform@v1
+    - uses: actions/checkout@v6
+    - uses: hashicorp/setup-terraform@v4
 
     - name: Terraform fmt
       id: fmt

--- a/.github/workflows/test-terraform-module.yml
+++ b/.github/workflows/test-terraform-module.yml
@@ -23,16 +23,16 @@ jobs:
       run:
         working-directory: ./tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 1800 # 30min
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v4
 
       - name: Terraform Init
         run: terraform init -upgrade

--- a/tests/rds.tf
+++ b/tests/rds.tf
@@ -1,5 +1,11 @@
+data "aws_rds_engine_version" "rds_mysql" {
+  engine       = "mysql"
+  default_only = true
+}
+
 locals {
-  rds_mysql_db_name = "tf-integrations-rds-mysql-${random_pet.this.id}"
+  rds_mysql_db_name     = "tf-integrations-rds-mysql-${random_pet.this.id}"
+  rds_mysql_major_minor = join(".", slice(split(".", data.aws_rds_engine_version.rds_mysql.version_actual), 0, 2))
 }
 
 module "rds_mysql_logs" {
@@ -20,21 +26,15 @@ module "rds_mysql_logs" {
 
 /*** RDS ***/
 
-
-data "aws_rds_engine_version" "rds_mysql" {
-  engine       = "mysql"
-  default_only = true
-}
 module "rds_mysql" {
   source = "terraform-aws-modules/rds/aws"
 
   identifier = local.rds_mysql_db_name
 
-  # All available versions: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt
   engine               = "mysql"
-  engine_version       = data.aws_rds_engine_version.rds_mysql.version
-  family               = "mysql8.0"
-  major_engine_version = "8.0"
+  engine_version       = local.rds_mysql_major_minor
+  family               = "mysql${local.rds_mysql_major_minor}"
+  major_engine_version = local.rds_mysql_major_minor
   instance_class       = "db.t3.micro"
 
 

--- a/tests/s3-logfile.tf
+++ b/tests/s3-logfile.tf
@@ -34,7 +34,7 @@ module "elb_logs" {
 //   cty.StringVal("honeycomb-tf-integrations-logs-decent-sunbird").
 
 data "aws_s3_bucket" "log_bucket" {
-  bucket = "honeycomb-tf-integrations-logs"
+  bucket = "terraform-integrations-test-logs"
 }
 
 /*** ALB ***/

--- a/tests/versions.tf
+++ b/tests/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Which problem is this PR solving?

- Address warnings in GHA workflows runs.

## Short description of the changes

- Updated actions
  - actions/checkout
  - hashicorp/setup-terraform
  - aws-actions/configure-aws-credentials

- Changes to tests
  - move minimum version of Terraform to 1.11.1
  - no hard-coded mysql versions, compute a minor once from the current AWS default version and use in all places
