### PR TITLE
maint(rds-logs, s3-logfile): update Lambda runtime from al2 (EOL) to al2023

### DIFF
--- a/modules/rds-logs/main.tf
+++ b/modules/rds-logs/main.tf
@@ -36,7 +36,7 @@ module "rds_lambda_transform" {
   function_name = "${var.name}-honeycomb-rds-${var.db_engine}-log-parser"
   description   = "Parses RDS logs coming off of Kinesis Firehose, sending them back to the Firehose as structured JSON events."
   handler       = "rds-${var.db_engine}-kfh-transform"
-  runtime       = "provided.al2"
+  runtime       = "provided.al2023"
   architectures = var.lambda_function_architecture == "amd64" ? ["x86_64"] : ["arm64"]
   memory_size   = var.lambda_function_memory
   timeout       = var.lambda_function_timeout

--- a/modules/s3-logfile/main.tf
+++ b/modules/s3-logfile/main.tf
@@ -42,7 +42,7 @@ module "s3_processor" {
   function_name = var.name
   description   = "Parses LB access logs from S3, sending them to Honeycomb as structured events"
   handler       = "s3-handler"
-  runtime       = "provided.al2"
+  runtime       = "provided.al2023"
   architectures = var.lambda_function_architecture == "amd64" ? ["x86_64"] : ["arm64"]
   memory_size   = var.lambda_function_memory
   timeout       = var.lambda_function_timeout


### PR DESCRIPTION
## Which problem is this PR solving?

AWS is ending support for the `provided.al2` OS-only lambda runtime we currently have hard-coded in our modules' use of Lambda.

- Closes #106 

## Short description of the changes

* Update `rds-logs` and `s3-logfile` modules to use `provided.al2023`

## How to verify that this has the expected result

CI shows the lambdas spun up use the newer runtime version.