### PR TITLE
fix(kinesis-firehose-honeycomb): correct multi-destination collector OTLP endpoint (404)

### DIFF
--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -54,8 +54,14 @@ locals {
         ]
       }
       batch = {
-        timeout         = "300s"
-        send_batch_size = 100000
+        # Honeycomb's OTLP /v1/metrics rejects oversized request bodies with HTTP 400
+        # "request body is too large". send_batch_max_size hard-caps each export so a
+        # single flush never exceeds that limit (the old send_batch_size=100000 with no
+        # max produced multi-MB posts that were dropped wholesale). Smaller timeout also
+        # bounds delivery latency and the collector's in-memory buffer.
+        timeout             = "10s"
+        send_batch_size     = 8192
+        send_batch_max_size = 8192
       }
     }
 

--- a/modules/kinesis-firehose-honeycomb/main.tf
+++ b/modules/kinesis-firehose-honeycomb/main.tf
@@ -31,15 +31,39 @@ locals {
   otel_config = {
     receivers = {
       awsfirehose = {
-        endpoint    = "0.0.0.0:4433"
+        endpoint = "0.0.0.0:4433"
+        # record_type is deprecated in favor of the awscloudwatchmetricstreams_encoding
+        # extension, but the honeycomb-opentelemetry-collector distro does not bundle
+        # that extension yet (valid extensions: health_check pprof zpages bearertokenauth
+        # headers_setter), so we keep the still-supported record_type form.
         record_type = "otlp_v1"
         access_key  = local.actual_otel_access_key
       }
     }
 
+    processors = {
+      # Drop the redundant MetricName datapoint attribute: it duplicates the OTLP
+      # metric name (e.g. amazonaws.com/AWS/Lambda/Invocations), matching the
+      # behavior of Honeycomb's native CloudWatch (kinesis_events) ingest endpoint.
+      "transform/drop_metric_name" = {
+        metric_statements = [
+          {
+            context    = "datapoint"
+            statements = ["delete_key(attributes, \"MetricName\")"]
+          }
+        ]
+      }
+      batch = {
+        timeout         = "300s"
+        send_batch_size = 100000
+      }
+    }
+
     exporters = {
-      for idx, dest in local.destinations : "otlphttp/${idx}" => {
-        endpoint = "${dest.honeycomb_api_host}/v1/metrics"
+      # metrics_endpoint is used verbatim; setting endpoint would make the exporter
+      # append /v1/metrics again, producing /v1/metrics/v1/metrics (404).
+      for idx, dest in local.destinations : "otlp_http/${idx}" => {
+        metrics_endpoint = "${dest.honeycomb_api_host}/v1/metrics"
         headers = {
           "x-honeycomb-team"    = dest.honeycomb_api_key
           "x-honeycomb-dataset" = dest.honeycomb_dataset_name
@@ -47,19 +71,12 @@ locals {
       }
     }
 
-    processors = {
-      batch = {
-        timeout         = "300s"
-        send_batch_size = 100000
-      }
-    }
-
     service = {
       pipelines = {
         metrics = {
           receivers  = ["awsfirehose"]
-          processors = ["batch"]
-          exporters  = [for idx, dest in local.destinations : "otlphttp/${idx}"]
+          processors = ["transform/drop_metric_name", "batch"]
+          exporters  = [for idx, dest in local.destinations : "otlp_http/${idx}"]
         }
       }
     }

--- a/modules/kinesis-firehose-honeycomb/variables.tf
+++ b/modules/kinesis-firehose-honeycomb/variables.tf
@@ -142,5 +142,5 @@ variable "otel_access_key" {
 variable "otel_collector_version" {
   type        = string
   description = "The version tag of the Honeycomb OpenTelemetry collector image to use."
-  default     = "v0.0.29"
+  default     = "v0.0.33"
 }


### PR DESCRIPTION
Closes #114.

## What

Fixes the multi-destination (App Runner collector) fan-out path of `kinesis-firehose-honeycomb`. That path (added in #95, never end-to-end verified per #107's unchecked test-plan box) generated an OTel Collector config that **dropped 100% of metrics**. Found by booting the pinned collector image with the module's generated config + a real CloudWatch Metric Streams record, then confirmed live from the infra repo.

### Changes

1. **Exporter endpoint (404).** Was `endpoint = "${host}/v1/metrics"`; the OTLP/HTTP exporter appends the signal path, so requests went to `…/v1/metrics/v1/metrics` → **HTTP 404, dropped**. → `metrics_endpoint` (used verbatim).
2. **Batch size (400).** The `batch` processor used `send_batch_size = 100000` with no `send_batch_max_size`, so the collector POSTed ~100k-datapoint (multi-MB) payloads → Honeycomb rejected them with **HTTP 400 "request body is too large"** (`dropped_items ~100521`). → `send_batch_max_size = 8192`, `send_batch_size = 8192`, `timeout = 10s`.
3. **Bump default `otel_collector_version` `v0.0.29` → `v0.0.33`.**
4. **`otlphttp/*` → `otlp_http/*`** (clears the deprecated-alias warning; `otlp_http` is bundled).
5. **`transform/drop_metric_name` processor** — deletes the redundant `MetricName` datapoint attribute, matching Honeycomb's native `kinesis_events` ingest endpoint (which strips it because it duplicates the OTLP metric name, e.g. `amazonaws.com/AWS/Lambda/Invocations`). Keeps event shape consistent across the direct-Firehose and collector paths.

### Deliberately NOT changed

- Receiver **`record_type = "otlp_v1"` is kept.** It's deprecated in favor of the `awscloudwatchmetricstreams_encoding` extension, but the `honeycomb-opentelemetry-collector` distro **does not bundle that extension** at v0.0.33 (verified: valid extensions are `health_check pprof zpages bearertokenauth headers_setter`) — referencing it crashes the collector at startup. Comment left in-code; revisit when the distro ships it.

## Test plan

- `terraform validate` passes on the module.
- Booted `honeycomb-opentelemetry-collector:v0.0.33` with the generated config: reaches "Everything is ready", no unknown-component errors (`otlp_http` + `transform` bundled; encoding extension is not). `awsfirehose` receiver auth-gates on the access key (401/200), accepts the CWMS `opentelemetry1.0` Firehose envelope.
- **Live-verified** by pinning an infra workspace to this branch and deploying: App Runner collector reaches `RUNNING`, the 404/400 errors stop across all three exporters, and CloudWatch metrics (`aws.exporter.arn = …/aws2hny-base-metrics`) flow into the destination metrics datasets — confirmed ramping from 0 (e.g. ~158k datapoints in one instance, ~240k in another within ~15 min). Honeycomb-side ref: SRE-2446.
