### PR TITLE
maint: fix CODEOWNERS, keep release prep PRs out of release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @honeycombio/oss-maintaners
+* @honeycombio/oss-maintainers

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
   exclude:
     labels:
       - no-changelog
+      - skip-changelog
   categories:
     - title: 💥 Breaking Changes 💥
       labels:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@
     - If recategorization or entry updates are needed, discard the edits to CHANGELOG.md, update the PR titles and labels accordingly back at GitHub, and rerun.
     - If the script picked up an unexpected previous version, you can override by including that, too: `PREVIOUS_VERSION=v2.2.0`
   - Commit changes, push, and open the PR for review.
-    - Label it `type: maintenance` and `version: no bump`
+    - Label it `type: maintenance`, `version: no bump`, and `no-changelog` to keep it out of the notes for the release it is preparing
 - Once the release prep PR is merged, apply a tag on the merge commit that matches the version to be released.
   - Fetch the updated `main` branch.
   - Apply a tag for the new version on the merged commit (e.g. `git tag -a v2.3.0 -m "v2.3.0"`)


### PR DESCRIPTION
## Which problem is this PR solving?

#117 showed up in the initial draft of v2.3.0 release notes ... which we don't want.

Also `skip-changelog` stopped having an effect on anything after release-drafter was removed in that PR. This isn't our usual label, but it _exists_, so the config should account for it.

And CODEOWNERS had a typo, so the team wasn't automatically getting review requests.

## Short description of the changes

- RELEASING instructions include labeling release prep PRs as `no-changelog`.
- Adds `skip-changelog` to the exclude list in `.github/release.yml`
- Fixes the misspelled team slug in CODEOWNERS.
